### PR TITLE
feat: add DisplayFrame polish pass

### DIFF
--- a/apps/client/src/features/display/displayScreen.logic.ts
+++ b/apps/client/src/features/display/displayScreen.logic.ts
@@ -1,4 +1,5 @@
 import type { WidgetKey } from "@ambient/shared-contracts";
+import { formatRefreshIntervalLabel, getWidgetRefreshIntervalMs, widgetManifests } from "../../widgets/widget.manifests";
 
 interface SelectableWidget {
   id: string;
@@ -27,17 +28,72 @@ export function selectDisplayWidget<TWidget extends SelectableWidget>(
 export function getDisplayRefreshIntervalMs(
   widgetType: WidgetKey | null | undefined,
 ): number | null {
-  if (widgetType === "clockDate") {
-    return 1000;
+  return getWidgetRefreshIntervalMs(widgetType);
+}
+
+type DisplayUiState =
+  | "loadingWidgets"
+  | "error"
+  | "empty"
+  | "loadingWidgetData"
+  | "ready"
+  | "unsupported";
+
+interface ResolveDisplayUiStateInput {
+  loadingWidgets: boolean;
+  loadingWidgetData: boolean;
+  hasError: boolean;
+  hasSelectedWidget: boolean;
+  hasWidgetData: boolean;
+}
+
+export function resolveDisplayUiState(input: ResolveDisplayUiStateInput): DisplayUiState {
+  if (input.loadingWidgets) {
+    return "loadingWidgets";
   }
 
-  if (widgetType === "weather") {
-    return 300000;
+  if (input.hasError) {
+    return "error";
   }
 
-  if (widgetType === "calendar") {
-    return 60000;
+  if (!input.hasSelectedWidget) {
+    return "empty";
   }
 
-  return null;
+  if (input.loadingWidgetData && !input.hasWidgetData) {
+    return "loadingWidgetData";
+  }
+
+  if (input.hasWidgetData) {
+    return "ready";
+  }
+
+  return "unsupported";
+}
+
+interface DisplayFrameModel {
+  title: string;
+  subtitle: string;
+  footerLabel: string;
+}
+
+export function getDisplayFrameModel(widgetType: WidgetKey | null | undefined): DisplayFrameModel {
+  if (!widgetType) {
+    return {
+      title: "Ambient Display",
+      subtitle: "Display Mode",
+      footerLabel: "Ambient Screen",
+    };
+  }
+
+  const manifest = widgetManifests[widgetType];
+  const refreshLabel = formatRefreshIntervalLabel(
+    getWidgetRefreshIntervalMs(widgetType),
+  );
+
+  return {
+    title: manifest.name,
+    subtitle: "Display Mode",
+    footerLabel: `Refresh ${refreshLabel}`,
+  };
 }

--- a/apps/client/src/features/display/screens/DisplayScreen.tsx
+++ b/apps/client/src/features/display/screens/DisplayScreen.tsx
@@ -19,7 +19,9 @@ import {
 } from "../services/orientation";
 import { DisplayFrame } from "../../../shared/ui/layout/DisplayFrame";
 import {
+  getDisplayFrameModel,
   getDisplayRefreshIntervalMs,
+  resolveDisplayUiState,
   selectDisplayWidget,
 } from "../displayScreen.logic";
 import { renderWidgetFromEnvelope } from "../../../widgets/widget.registry";
@@ -132,63 +134,63 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
     };
   }, [selectedWidgetId, selectedWidget?.type]);
 
+  const uiState = resolveDisplayUiState({
+    loadingWidgets,
+    loadingWidgetData,
+    hasError: !!error,
+    hasSelectedWidget: !!selectedWidget,
+    hasWidgetData: !!widgetData,
+  });
+
+  const frameModel = getDisplayFrameModel(selectedWidget?.type);
+
   const content = useMemo(() => {
-    if (loadingWidgets) {
+    if (uiState === "loadingWidgets") {
       return (
-        <DisplayFrame title="Display Mode">
-          <View style={styles.centered}>
-            <ActivityIndicator size="large" color="#fff" />
-            <Text style={styles.message}>Loading widgets...</Text>
-          </View>
-        </DisplayFrame>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#fff" />
+          <Text style={styles.message}>Loading widgets...</Text>
+        </View>
       );
     }
 
-    if (error) {
+    if (uiState === "error") {
       return (
-        <DisplayFrame title="Display Mode">
-          <View style={styles.centered}>
-            <Text style={styles.error}>{error}</Text>
-          </View>
-        </DisplayFrame>
+        <View style={styles.centered}>
+          <Text style={styles.error}>{error}</Text>
+        </View>
       );
     }
 
-    if (!selectedWidget) {
+    if (uiState === "empty") {
       return (
-        <DisplayFrame title="Display Mode">
-          <View style={styles.centered}>
-            <Text style={styles.message}>No widgets configured yet.</Text>
-          </View>
-        </DisplayFrame>
+        <View style={styles.centered}>
+          <Text style={styles.message}>No widgets configured yet.</Text>
+        </View>
       );
     }
 
-    if (loadingWidgetData && !widgetData) {
+    if (uiState === "loadingWidgetData") {
       return (
-        <DisplayFrame title="Display Mode">
-          <View style={styles.centered}>
-            <ActivityIndicator size="large" color="#fff" />
-            <Text style={styles.message}>Loading widget data...</Text>
-          </View>
-        </DisplayFrame>
+        <View style={styles.centered}>
+          <ActivityIndicator size="large" color="#fff" />
+          <Text style={styles.message}>Loading widget data...</Text>
+        </View>
       );
     }
 
-    if (widgetData) {
+    if (uiState === "ready" && widgetData) {
       return renderWidgetFromEnvelope(widgetData);
     }
 
     return (
-      <DisplayFrame title="Display Mode">
-        <View style={styles.centered}>
-          <Text style={styles.message}>
-            Unsupported widget type: {selectedWidget.type}
-          </Text>
-        </View>
-      </DisplayFrame>
+      <View style={styles.centered}>
+        <Text style={styles.message}>
+          Unsupported widget type: {selectedWidget?.type}
+        </Text>
+      </View>
     );
-  }, [loadingWidgets, loadingWidgetData, error, selectedWidget, widgetData]);
+  }, [uiState, error, widgetData, selectedWidget?.type]);
 
   return (
     <View style={styles.screen}>
@@ -203,7 +205,13 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
           </Pressable>
         </View>
       ) : null}
-      {content}
+      <DisplayFrame
+        title={frameModel.title}
+        subtitle={frameModel.subtitle}
+        footer={<Text style={styles.footerText}>{frameModel.footerLabel}</Text>}
+      >
+        {content}
+      </DisplayFrame>
     </View>
   );
 }
@@ -249,5 +257,9 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: "#ff6b6b",
     textAlign: "center",
+  },
+  footerText: {
+    color: "#666",
+    fontSize: 12,
   },
 });

--- a/apps/client/src/widgets/calendar/renderer.tsx
+++ b/apps/client/src/widgets/calendar/renderer.tsx
@@ -4,15 +4,13 @@ import type {
   CalendarWidgetData,
   WidgetRendererProps,
 } from "@ambient/shared-contracts";
-import { DisplayFrame } from "../../shared/ui/layout/DisplayFrame";
 
 export function CalendarRenderer({ data }: WidgetRendererProps<CalendarWidgetData>) {
   return (
-    <DisplayFrame title="Calendar" subtitle={data ? `${data.upcomingCount} events` : "Calendar"}>
-      <View style={styles.container}>
-        <Text style={styles.message}>Calendar widget coming soon.</Text>
-      </View>
-    </DisplayFrame>
+    <View style={styles.container}>
+      <Text style={styles.message}>Calendar widget coming soon.</Text>
+      {data ? <Text style={styles.count}>{data.upcomingCount} events</Text> : null}
+    </View>
   );
 }
 
@@ -27,6 +25,12 @@ const styles = StyleSheet.create({
   message: {
     fontSize: 20,
     color: "#fff",
+    textAlign: "center",
+  },
+  count: {
+    marginTop: 12,
+    fontSize: 16,
+    color: "#aaa",
     textAlign: "center",
   },
 });

--- a/apps/client/src/widgets/clockDate/renderer.tsx
+++ b/apps/client/src/widgets/clockDate/renderer.tsx
@@ -4,35 +4,26 @@ import type {
   ClockDateWidgetData,
   WidgetRendererProps,
 } from "@ambient/shared-contracts";
-import { DisplayFrame } from "../../shared/ui/layout/DisplayFrame";
 
 export function ClockDateRenderer({ data }: WidgetRendererProps<ClockDateWidgetData>) {
   if (!data) {
     return (
-      <DisplayFrame title="Clock">
-        <View style={styles.container}>
-          <Text style={styles.loadingText}>No clock data</Text>
-        </View>
-      </DisplayFrame>
+      <View style={styles.container}>
+        <Text style={styles.loadingText}>No clock data</Text>
+      </View>
     );
   }
 
   return (
-    <DisplayFrame
-      title="Clock"
-      subtitle={data.nowIso}
-      footer={<Text style={styles.footerText}>Ambient Screen</Text>}
-    >
-      <View style={styles.container}>
-        <Text style={styles.time}>{data.formattedTime}</Text>
-        {data.weekdayLabel ? (
-          <Text style={styles.weekday}>{data.weekdayLabel}</Text>
-        ) : null}
-        {data.formattedDate ? (
-          <Text style={styles.date}>{data.formattedDate}</Text>
-        ) : null}
-      </View>
-    </DisplayFrame>
+    <View style={styles.container}>
+      <Text style={styles.time}>{data.formattedTime}</Text>
+      {data.weekdayLabel ? (
+        <Text style={styles.weekday}>{data.weekdayLabel}</Text>
+      ) : null}
+      {data.formattedDate ? (
+        <Text style={styles.date}>{data.formattedDate}</Text>
+      ) : null}
+    </View>
   );
 }
 
@@ -62,9 +53,5 @@ const styles = StyleSheet.create({
   loadingText: {
     fontSize: 20,
     color: "#fff",
-  },
-  footerText: {
-    color: "#666",
-    fontSize: 12,
   },
 });

--- a/apps/client/src/widgets/weather/renderer.tsx
+++ b/apps/client/src/widgets/weather/renderer.tsx
@@ -4,15 +4,13 @@ import type {
   WeatherWidgetData,
   WidgetRendererProps,
 } from "@ambient/shared-contracts";
-import { DisplayFrame } from "../../shared/ui/layout/DisplayFrame";
 
 export function WeatherRenderer({ data }: WidgetRendererProps<WeatherWidgetData>) {
   return (
-    <DisplayFrame title="Weather" subtitle={data?.location ?? "Weather"}>
-      <View style={styles.container}>
-        <Text style={styles.message}>Weather widget coming soon.</Text>
-      </View>
-    </DisplayFrame>
+    <View style={styles.container}>
+      <Text style={styles.message}>Weather widget coming soon.</Text>
+      {data?.location ? <Text style={styles.location}>{data.location}</Text> : null}
+    </View>
   );
 }
 
@@ -27,6 +25,12 @@ const styles = StyleSheet.create({
   message: {
     fontSize: 20,
     color: "#fff",
+    textAlign: "center",
+  },
+  location: {
+    marginTop: 12,
+    fontSize: 16,
+    color: "#aaa",
     textAlign: "center",
   },
 });

--- a/apps/client/src/widgets/widget.manifests.ts
+++ b/apps/client/src/widgets/widget.manifests.ts
@@ -1,0 +1,45 @@
+import type { WidgetKey, WidgetManifest, WidgetRefreshPolicy } from "@ambient/shared-contracts";
+
+const refreshPolicyByWidget: { [TKey in WidgetKey]: WidgetRefreshPolicy } = {
+  clockDate: { intervalMs: 1000 },
+  weather: { intervalMs: 300000 },
+  calendar: { intervalMs: 60000 },
+};
+
+export const widgetManifests: { [TKey in WidgetKey]: WidgetManifest<TKey> } = {
+  clockDate: {
+    key: "clockDate",
+    name: "Clock & Date",
+    refreshPolicy: refreshPolicyByWidget.clockDate,
+  },
+  weather: {
+    key: "weather",
+    name: "Weather",
+    refreshPolicy: refreshPolicyByWidget.weather,
+  },
+  calendar: {
+    key: "calendar",
+    name: "Calendar",
+    refreshPolicy: refreshPolicyByWidget.calendar,
+  },
+};
+
+export function getWidgetRefreshIntervalMs(widgetKey: WidgetKey | null | undefined): number | null {
+  if (!widgetKey) {
+    return null;
+  }
+
+  return widgetManifests[widgetKey].refreshPolicy.intervalMs;
+}
+
+export function formatRefreshIntervalLabel(intervalMs: number | null): string {
+  if (intervalMs === null) {
+    return "manual refresh";
+  }
+
+  if (intervalMs < 60000) {
+    return `every ${Math.floor(intervalMs / 1000)}s`;
+  }
+
+  return `every ${Math.floor(intervalMs / 60000)}m`;
+}

--- a/apps/client/src/widgets/widget.registry.tsx
+++ b/apps/client/src/widgets/widget.registry.tsx
@@ -2,9 +2,6 @@ import React from "react";
 import type {
   WidgetDataByKey,
   WidgetDataEnvelope,
-  WidgetKey,
-  WidgetManifest,
-  WidgetRefreshPolicy,
 } from "@ambient/shared-contracts";
 import { CalendarRenderer } from "./calendar/renderer";
 import { ClockDateRenderer } from "./clockDate/renderer";
@@ -14,38 +11,6 @@ type WidgetEnvelope =
   | WidgetDataEnvelope<WidgetDataByKey["clockDate"], "clockDate">
   | WidgetDataEnvelope<WidgetDataByKey["weather"], "weather">
   | WidgetDataEnvelope<WidgetDataByKey["calendar"], "calendar">;
-
-const refreshPolicyByWidget: { [TKey in WidgetKey]: WidgetRefreshPolicy } = {
-  clockDate: { intervalMs: 1000 },
-  weather: { intervalMs: 300000 },
-  calendar: { intervalMs: 60000 },
-};
-
-export const widgetManifests: { [TKey in WidgetKey]: WidgetManifest<TKey> } = {
-  clockDate: {
-    key: "clockDate",
-    name: "Clock & Date",
-    refreshPolicy: refreshPolicyByWidget.clockDate,
-  },
-  weather: {
-    key: "weather",
-    name: "Weather",
-    refreshPolicy: refreshPolicyByWidget.weather,
-  },
-  calendar: {
-    key: "calendar",
-    name: "Calendar",
-    refreshPolicy: refreshPolicyByWidget.calendar,
-  },
-};
-
-export function getWidgetRefreshIntervalMs(widgetKey: WidgetKey | null | undefined): number | null {
-  if (!widgetKey) {
-    return null;
-  }
-
-  return widgetManifests[widgetKey].refreshPolicy.intervalMs;
-}
 
 export function renderWidgetFromEnvelope(envelope: WidgetEnvelope) {
   if (envelope.widgetKey === "clockDate") {

--- a/apps/client/tests/displayScreen.logic.test.ts
+++ b/apps/client/tests/displayScreen.logic.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  getDisplayFrameModel,
   getDisplayRefreshIntervalMs,
+  resolveDisplayUiState,
   selectDisplayWidget,
 } from "../src/features/display/displayScreen.logic";
 
@@ -60,4 +62,80 @@ test("getDisplayRefreshIntervalMs follows widget refresh policy rules", () => {
   assert.equal(getDisplayRefreshIntervalMs("weather"), 300000);
   assert.equal(getDisplayRefreshIntervalMs("calendar"), 60000);
   assert.equal(getDisplayRefreshIntervalMs(undefined), null);
+});
+
+test("resolveDisplayUiState returns loadingWidgets while widgets are loading", () => {
+  const state = resolveDisplayUiState({
+    loadingWidgets: true,
+    loadingWidgetData: false,
+    hasError: false,
+    hasSelectedWidget: false,
+    hasWidgetData: false,
+  });
+
+  assert.equal(state, "loadingWidgets");
+});
+
+test("resolveDisplayUiState returns error before empty state", () => {
+  const state = resolveDisplayUiState({
+    loadingWidgets: false,
+    loadingWidgetData: false,
+    hasError: true,
+    hasSelectedWidget: false,
+    hasWidgetData: false,
+  });
+
+  assert.equal(state, "error");
+});
+
+test("resolveDisplayUiState returns loadingWidgetData while waiting for first payload", () => {
+  const state = resolveDisplayUiState({
+    loadingWidgets: false,
+    loadingWidgetData: true,
+    hasError: false,
+    hasSelectedWidget: true,
+    hasWidgetData: false,
+  });
+
+  assert.equal(state, "loadingWidgetData");
+});
+
+test("resolveDisplayUiState returns ready when widget data exists", () => {
+  const state = resolveDisplayUiState({
+    loadingWidgets: false,
+    loadingWidgetData: false,
+    hasError: false,
+    hasSelectedWidget: true,
+    hasWidgetData: true,
+  });
+
+  assert.equal(state, "ready");
+});
+
+test("resolveDisplayUiState returns unsupported for selected widget without payload", () => {
+  const state = resolveDisplayUiState({
+    loadingWidgets: false,
+    loadingWidgetData: false,
+    hasError: false,
+    hasSelectedWidget: true,
+    hasWidgetData: false,
+  });
+
+  assert.equal(state, "unsupported");
+});
+
+test("getDisplayFrameModel returns default shell when no widget is selected", () => {
+  const model = getDisplayFrameModel(undefined);
+
+  assert.equal(model.title, "Ambient Display");
+  assert.equal(model.subtitle, "Display Mode");
+  assert.equal(model.footerLabel, "Ambient Screen");
+});
+
+test("getDisplayFrameModel includes manifest title and refresh policy label", () => {
+  const model = getDisplayFrameModel("weather");
+
+  assert.equal(model.title, "Weather");
+  assert.equal(model.subtitle, "Display Mode");
+  assert.equal(model.footerLabel, "Refresh every 5m");
 });


### PR DESCRIPTION
## Summary\n- Implement M2-2 DisplayFrame polish pass with a single shared display shell\n- Standardize loading/empty/error/unsupported states in DisplayScreen\n- Move widget manifests to a dedicated module and reuse refresh policy in display logic\n- Make widget renderers content-only so all widgets render within the same frame\n- Add unit tests for display state resolution and frame metadata\n\n## Verification\n- cd apps/client && npm test\n- cd apps/client && npm run typecheck\n- cd apps/client && npm run lint\n- cd apps/api && npm run typecheck\n- cd apps/api && npm run lint\n- cd apps/api && npm run build\n- API runtime smoke test: boot on PORT=3017 and GET /health\n\nCloses #19