### PR TITLE
feat: add calendar admin config flow

### DIFF
--- a/apps/api/src/modules/widgetData/resolvers/calendar.resolver.ts
+++ b/apps/api/src/modules/widgetData/resolvers/calendar.resolver.ts
@@ -16,6 +16,27 @@ function buildEmptyCalendarData(): CalendarWidgetData {
   };
 }
 
+function buildWindowBounds(timeWindow: "today" | "next24h" | "next7d"): {
+  windowStartIso: string;
+  windowEndIso: string;
+} {
+  const windowStart = new Date();
+  const windowEnd = new Date(windowStart);
+
+  if (timeWindow === "today") {
+    windowEnd.setUTCHours(23, 59, 59, 999);
+  } else if (timeWindow === "next24h") {
+    windowEnd.setUTCHours(windowEnd.getUTCHours() + 24);
+  } else {
+    windowEnd.setUTCDate(windowEnd.getUTCDate() + 7);
+  }
+
+  return {
+    windowStartIso: windowStart.toISOString(),
+    windowEndIso: windowEnd.toISOString(),
+  };
+}
+
 export async function resolveCalendarWidgetData(input: {
   widgetInstanceId: string;
   widgetConfig: unknown;
@@ -32,36 +53,34 @@ export async function resolveCalendarWidgetData(input: {
     input.widgetConfig,
   ) as WidgetConfigByKey["calendar"];
 
-  const sourceType = normalizedConfig.sourceType ?? "ical";
-  const feedUrl = normalizedConfig.feedUrl;
-  const lookAheadDays = normalizedConfig.lookAheadDays ?? 7;
+  const provider = normalizedConfig.provider ?? "ical";
+  const account = normalizedConfig.account;
+  const timeWindow = normalizedConfig.timeWindow ?? "next7d";
   const includeAllDay = normalizedConfig.includeAllDay ?? true;
   const maxEvents = normalizedConfig.maxEvents ?? 10;
 
-  if (!feedUrl) {
+  if (!account) {
     return {
       widgetInstanceId: input.widgetInstanceId,
       widgetKey: "calendar",
       state: "empty",
       data: buildEmptyCalendarData(),
       meta: {
-        source: sourceType,
+        source: provider,
         errorCode: "CALENDAR_FEED_NOT_CONFIGURED",
-        message: "Calendar feed URL is not configured.",
+        message: "Calendar account is not configured.",
       },
     };
   }
 
   const fetchCalendarData = input.fetchCalendarData ?? fetchIcsCalendarEvents;
-  const windowStart = new Date();
-  const windowEnd = new Date(windowStart);
-  windowEnd.setUTCDate(windowEnd.getUTCDate() + lookAheadDays);
+  const { windowStartIso, windowEndIso } = buildWindowBounds(timeWindow);
 
   try {
     const providerResult = await fetchCalendarData({
-      feedUrl,
-      windowStartIso: windowStart.toISOString(),
-      windowEndIso: windowEnd.toISOString(),
+      feedUrl: account,
+      windowStartIso,
+      windowEndIso,
       includeAllDay,
       maxEvents,
     });
@@ -73,7 +92,7 @@ export async function resolveCalendarWidgetData(input: {
         state: "empty",
         data: buildEmptyCalendarData(),
         meta: {
-          source: sourceType,
+          source: provider,
           fetchedAt: providerResult.fetchedAtIso,
           message: "No upcoming events in the configured time window.",
         },
@@ -89,7 +108,7 @@ export async function resolveCalendarWidgetData(input: {
         events: providerResult.events,
       },
       meta: {
-        source: sourceType,
+        source: provider,
         fetchedAt: providerResult.fetchedAtIso,
       },
     };
@@ -100,7 +119,7 @@ export async function resolveCalendarWidgetData(input: {
       state: "stale",
       data: buildEmptyCalendarData(),
       meta: {
-        source: sourceType,
+        source: provider,
         errorCode: "CALENDAR_PROVIDER_UNAVAILABLE",
         message: "Calendar provider request failed.",
       },

--- a/apps/api/src/modules/widgets/widget-contracts.ts
+++ b/apps/api/src/modules/widgets/widget-contracts.ts
@@ -49,13 +49,16 @@ const weatherConfigSchema: z.ZodType<WidgetConfigByKey["weather"]> = z
   })
   .strict();
 
-const calendarConfigSchema: z.ZodType<WidgetConfigByKey["calendar"]> = z
+const calendarConfigSchema = z
   .object({
+    provider: z.literal("ical").optional(),
+    account: z.string().url().optional(),
+    timeWindow: z.enum(["today", "next24h", "next7d"]).optional(),
+    maxEvents: z.number().int().min(1).max(20).optional(),
+    includeAllDay: z.boolean().optional(),
     sourceType: z.literal("ical").optional(),
     feedUrl: z.string().url().optional(),
     lookAheadDays: z.number().int().min(1).max(31).optional(),
-    maxEvents: z.number().int().min(1).max(20).optional(),
-    includeAllDay: z.boolean().optional(),
   })
   .strict();
 
@@ -80,8 +83,8 @@ export function getDefaultWidgetConfig(
   }
 
   return {
-    sourceType: "ical",
-    lookAheadDays: 7,
+    provider: "ical",
+    timeWindow: "next7d",
     maxEvents: 10,
     includeAllDay: true,
   };
@@ -114,9 +117,32 @@ export function normalizeWidgetConfig(
   }
 
   const defaultConfig = getDefaultWidgetConfig(widgetType) as Record<string, unknown>;
+  const parsedConfig = parseResult.data as Record<string, unknown>;
+
+  if (widgetType === "calendar") {
+    const provider = parsedConfig.provider ?? parsedConfig.sourceType ?? defaultConfig.provider;
+    const account = parsedConfig.account ?? parsedConfig.feedUrl;
+    const timeWindow =
+      parsedConfig.timeWindow ??
+      (typeof parsedConfig.lookAheadDays === "number"
+        ? parsedConfig.lookAheadDays <= 1
+          ? "today"
+          : parsedConfig.lookAheadDays <= 2
+            ? "next24h"
+            : "next7d"
+        : defaultConfig.timeWindow);
+
+    return {
+      provider,
+      ...(account ? { account } : {}),
+      timeWindow,
+      maxEvents: parsedConfig.maxEvents ?? defaultConfig.maxEvents,
+      includeAllDay: parsedConfig.includeAllDay ?? defaultConfig.includeAllDay,
+    } as Prisma.InputJsonValue;
+  }
 
   return {
     ...defaultConfig,
-    ...(parseResult.data as Record<string, unknown>),
+    ...parsedConfig,
   } as Prisma.InputJsonValue;
 }

--- a/apps/api/tests/m1-2-create-widget-flow.integration.test.ts
+++ b/apps/api/tests/m1-2-create-widget-flow.integration.test.ts
@@ -303,6 +303,61 @@ test("M3-3: weather widget creation rejects invalid units config", async () => {
   assert.equal(createResponse.statusCode, 400);
 });
 
+test("M4-3: calendar widget can be created with provider, account, and time window config", async () => {
+  await invokeRoute(usersRouter, "post", "/", {
+    body: { email: "owner@ambient.dev" }
+  });
+
+  const createResponse = await invokeRoute(widgetsRouter, "post", "/", {
+    body: {
+      type: "calendar",
+      config: {
+        provider: "ical",
+        account: "https://calendar.example.com/work.ics",
+        timeWindow: "next24h",
+        maxEvents: 8,
+        includeAllDay: false
+      }
+    }
+  });
+  assert.equal(createResponse.statusCode, 201);
+
+  const createdWidget = createResponse.body as {
+    type: string;
+    config: {
+      provider?: string;
+      account?: string;
+      timeWindow?: string;
+      maxEvents?: number;
+      includeAllDay?: boolean;
+    };
+  };
+  assert.equal(createdWidget.type, "calendar");
+  assert.equal(createdWidget.config.provider, "ical");
+  assert.equal(createdWidget.config.account, "https://calendar.example.com/work.ics");
+  assert.equal(createdWidget.config.timeWindow, "next24h");
+  assert.equal(createdWidget.config.maxEvents, 8);
+  assert.equal(createdWidget.config.includeAllDay, false);
+});
+
+test("M4-3: calendar widget creation rejects invalid provider/time window config", async () => {
+  await invokeRoute(usersRouter, "post", "/", {
+    body: { email: "owner@ambient.dev" }
+  });
+
+  const createResponse = await invokeRoute(widgetsRouter, "post", "/", {
+    body: {
+      type: "calendar",
+      config: {
+        provider: "googleCalendar",
+        account: "not-a-url",
+        timeWindow: "next30d"
+      }
+    }
+  });
+  assert.equal(createResponse.statusCode, 400);
+});
+
 test("M2-1: widget config must match widget contract schema", async () => {
   await invokeRoute(usersRouter, "post", "/", {
     body: { email: "owner@ambient.dev" }
@@ -322,7 +377,7 @@ test("M2-1: widget config must match widget contract schema", async () => {
     body: {
       type: "calendar",
       config: {
-        lookAheadDays: 99
+        maxEvents: 99
       }
     }
   });

--- a/apps/api/tests/m4-1-calendar-widget-backend.integration.test.ts
+++ b/apps/api/tests/m4-1-calendar-widget-backend.integration.test.ts
@@ -261,9 +261,9 @@ test("M4-1: calendar widget data endpoint returns normalized event list", async 
     body: {
       type: "calendar",
       config: {
-        sourceType: "ical",
-        feedUrl: "https://calendar.example.com/demo.ics",
-        lookAheadDays: 7,
+        provider: "ical",
+        account: "https://calendar.example.com/demo.ics",
+        timeWindow: "next7d",
         maxEvents: 5,
         includeAllDay: true,
       },
@@ -327,8 +327,8 @@ test("M4-1: calendar widget data endpoint returns empty when feed is not configu
     body: {
       type: "calendar",
       config: {
-        sourceType: "ical",
-        lookAheadDays: 7,
+        provider: "ical",
+        timeWindow: "next7d",
       },
     },
   });

--- a/apps/api/tests/widget-contracts.unit.test.ts
+++ b/apps/api/tests/widget-contracts.unit.test.ts
@@ -21,7 +21,7 @@ test("M2-1: createWidgetSchema accepts valid per-widget config shapes", () => {
 
   const calendar = createWidgetSchema.safeParse({
     type: "calendar",
-    config: { lookAheadDays: 7 },
+    config: { provider: "ical", timeWindow: "next7d" },
   });
   assert.equal(calendar.success, true);
 });
@@ -41,7 +41,7 @@ test("M2-1: createWidgetSchema rejects config shape mismatches", () => {
 
   const invalidCalendar = createWidgetSchema.safeParse({
     type: "calendar",
-    config: { lookAheadDays: 45 },
+    config: { provider: "googleCalendar" },
   });
   assert.equal(invalidCalendar.success, false);
 });
@@ -58,9 +58,26 @@ test("M2-1: normalizeWidgetConfig falls back to defaults for invalid input", () 
 
   const normalizedCalendar = normalizeWidgetConfig("calendar", {});
   assert.deepEqual(normalizedCalendar, {
-    sourceType: "ical",
-    lookAheadDays: 7,
+    provider: "ical",
+    timeWindow: "next7d",
     maxEvents: 10,
+    includeAllDay: true,
+  });
+});
+
+test("M4-3: normalizeWidgetConfig maps legacy calendar config to V1 admin shape", () => {
+  const normalizedCalendar = normalizeWidgetConfig("calendar", {
+    sourceType: "ical",
+    feedUrl: "https://calendar.example.com/feed.ics",
+    lookAheadDays: 7,
+    maxEvents: 5,
+  });
+
+  assert.deepEqual(normalizedCalendar, {
+    provider: "ical",
+    account: "https://calendar.example.com/feed.ics",
+    timeWindow: "next7d",
+    maxEvents: 5,
     includeAllDay: true,
   });
 });

--- a/apps/api/tests/widget-data.service.unit.test.ts
+++ b/apps/api/tests/widget-data.service.unit.test.ts
@@ -123,9 +123,9 @@ test("calendar resolver returns normalized events with all-day and timed entries
   const result = await resolveCalendarWidgetData({
     widgetInstanceId: "widget-calendar",
     widgetConfig: {
-      sourceType: "ical",
-      feedUrl: "https://calendar.example.com/feed.ics",
-      lookAheadDays: 7,
+      provider: "ical",
+      account: "https://calendar.example.com/feed.ics",
+      timeWindow: "next7d",
       includeAllDay: true,
       maxEvents: 5,
     },
@@ -177,12 +177,12 @@ test("calendar resolver returns normalized events with all-day and timed entries
   assert.equal(result.meta?.fetchedAt, "2026-03-20T12:34:56.000Z");
 });
 
-test("calendar resolver returns empty when feed URL is missing", async () => {
+test("calendar resolver returns empty when account is missing", async () => {
   const result = await resolveCalendarWidgetData({
     widgetInstanceId: "widget-calendar",
     widgetConfig: {
-      sourceType: "ical",
-      lookAheadDays: 7,
+      provider: "ical",
+      timeWindow: "next7d",
       maxEvents: 5,
       includeAllDay: true,
     },
@@ -200,9 +200,9 @@ test("calendar resolver returns stale when provider fails", async () => {
   const result = await resolveCalendarWidgetData({
     widgetInstanceId: "widget-calendar",
     widgetConfig: {
-      sourceType: "ical",
-      feedUrl: "https://calendar.example.com/feed.ics",
-      lookAheadDays: 7,
+      provider: "ical",
+      account: "https://calendar.example.com/feed.ics",
+      timeWindow: "next7d",
       includeAllDay: false,
       maxEvents: 3,
     },

--- a/apps/client/src/features/admin/adminHome.logic.ts
+++ b/apps/client/src/features/admin/adminHome.logic.ts
@@ -1,4 +1,8 @@
-import type { CreateWidgetInput, WeatherWidgetConfig } from "@ambient/shared-contracts";
+import type {
+  CalendarWidgetConfig,
+  CreateWidgetInput,
+  WeatherWidgetConfig,
+} from "@ambient/shared-contracts";
 
 interface ActiveWidgetCandidate {
   id: string;
@@ -9,15 +13,27 @@ export const CREATABLE_WIDGET_TYPES = ["clockDate", "weather", "calendar"] as co
 export type CreatableWidgetType = (typeof CREATABLE_WIDGET_TYPES)[number];
 export const WEATHER_UNITS = ["metric", "imperial"] as const;
 export type WeatherUnit = (typeof WEATHER_UNITS)[number];
+export const CALENDAR_PROVIDERS = ["ical"] as const;
+export type CalendarProvider = (typeof CALENDAR_PROVIDERS)[number];
+export const CALENDAR_TIME_WINDOWS = ["today", "next24h", "next7d"] as const;
+export type CalendarTimeWindow = (typeof CALENDAR_TIME_WINDOWS)[number];
 
 export function buildCreateWidgetInput(input: {
   widgetType: CreatableWidgetType;
   weatherConfig: WeatherWidgetConfig;
+  calendarConfig: CalendarWidgetConfig;
 }): CreateWidgetInput {
   if (input.widgetType === "weather") {
     return {
       type: "weather",
       config: input.weatherConfig,
+    };
+  }
+
+  if (input.widgetType === "calendar") {
+    return {
+      type: "calendar",
+      config: input.calendarConfig,
     };
   }
 

--- a/apps/client/src/features/admin/screens/AdminHomeScreen.tsx
+++ b/apps/client/src/features/admin/screens/AdminHomeScreen.tsx
@@ -16,6 +16,10 @@ import {
 } from "../../../services/api/widgetsApi";
 import {
   buildCreateWidgetInput,
+  CALENDAR_PROVIDERS,
+  CALENDAR_TIME_WINDOWS,
+  type CalendarProvider,
+  type CalendarTimeWindow,
   CREATABLE_WIDGET_TYPES,
   type CreatableWidgetType,
   WEATHER_UNITS,
@@ -33,6 +37,9 @@ export function AdminHomeScreen({ onEnterDisplayMode }: AdminHomeScreenProps) {
     useState<CreatableWidgetType>(CREATABLE_WIDGET_TYPES[0]);
   const [weatherLocation, setWeatherLocation] = useState("Amsterdam");
   const [weatherUnits, setWeatherUnits] = useState<WeatherUnit>("metric");
+  const [calendarProvider, setCalendarProvider] = useState<CalendarProvider>("ical");
+  const [calendarAccount, setCalendarAccount] = useState("");
+  const [calendarTimeWindow, setCalendarTimeWindow] = useState<CalendarTimeWindow>("next7d");
   const [loading, setLoading] = useState(true);
   const [creatingWidget, setCreatingWidget] = useState(false);
   const [settingActiveWidgetId, setSettingActiveWidgetId] = useState<string | null>(null);
@@ -86,6 +93,11 @@ export function AdminHomeScreen({ onEnterDisplayMode }: AdminHomeScreenProps) {
           weatherConfig: {
             location: weatherLocation,
             units: weatherUnits,
+          },
+          calendarConfig: {
+            provider: calendarProvider,
+            account: calendarAccount || undefined,
+            timeWindow: calendarTimeWindow,
           },
         }),
       );
@@ -193,6 +205,58 @@ export function AdminHomeScreen({ onEnterDisplayMode }: AdminHomeScreenProps) {
                   >
                     <Text style={[styles.unitButtonLabel, selected && styles.unitButtonLabelSelected]}>
                       {unit}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+        ) : selectedWidgetType === "calendar" ? (
+          <View style={styles.calendarConfig}>
+            <Text style={styles.weatherConfigLabel}>Provider</Text>
+            <View style={styles.unitsRow}>
+              {CALENDAR_PROVIDERS.map((provider) => {
+                const selected = calendarProvider === provider;
+
+                return (
+                  <Pressable
+                    key={provider}
+                    accessibilityRole="button"
+                    style={[styles.unitButton, selected && styles.unitButtonSelected]}
+                    onPress={() => setCalendarProvider(provider)}
+                  >
+                    <Text style={[styles.unitButtonLabel, selected && styles.unitButtonLabelSelected]}>
+                      {provider}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+            <Text style={styles.weatherConfigLabel}>Account (iCal URL)</Text>
+            <TextInput
+              accessibilityLabel="Calendar account"
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.textInput}
+              value={calendarAccount}
+              onChangeText={setCalendarAccount}
+              placeholder="https://calendar.example.com/feed.ics"
+              placeholderTextColor="#7f7f7f"
+            />
+            <Text style={styles.weatherConfigLabel}>Time window</Text>
+            <View style={styles.unitsRow}>
+              {CALENDAR_TIME_WINDOWS.map((window) => {
+                const selected = calendarTimeWindow === window;
+
+                return (
+                  <Pressable
+                    key={window}
+                    accessibilityRole="button"
+                    style={[styles.unitButton, selected && styles.unitButtonSelected]}
+                    onPress={() => setCalendarTimeWindow(window)}
+                  >
+                    <Text style={[styles.unitButtonLabel, selected && styles.unitButtonLabelSelected]}>
+                      {window}
                     </Text>
                   </Pressable>
                 );
@@ -311,6 +375,9 @@ const styles = StyleSheet.create({
     opacity: 0.6,
   },
   weatherConfig: {
+    gap: 8,
+  },
+  calendarConfig: {
     gap: 8,
   },
   weatherConfigLabel: {

--- a/apps/client/tests/adminHome.logic.test.ts
+++ b/apps/client/tests/adminHome.logic.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildCreateWidgetInput,
+  CALENDAR_PROVIDERS,
+  CALENDAR_TIME_WINDOWS,
   CREATABLE_WIDGET_TYPES,
   WEATHER_UNITS,
   selectAdminActiveWidget
@@ -47,13 +49,23 @@ test("WEATHER_UNITS exposes weather unit options for admin config", () => {
   assert.deepEqual(WEATHER_UNITS, ["metric", "imperial"]);
 });
 
+test("calendar admin config options expose providers and time windows", () => {
+  assert.deepEqual(CALENDAR_PROVIDERS, ["ical"]);
+  assert.deepEqual(CALENDAR_TIME_WINDOWS, ["today", "next24h", "next7d"]);
+});
+
 test("buildCreateWidgetInput omits config for non-weather widgets", () => {
   const payload = buildCreateWidgetInput({
     widgetType: "clockDate",
     weatherConfig: {
       location: "Amsterdam",
       units: "metric"
-    }
+    },
+    calendarConfig: {
+      provider: "ical",
+      account: "https://calendar.example.com/feed.ics",
+      timeWindow: "next7d",
+    },
   });
 
   assert.deepEqual(payload, { type: "clockDate" });
@@ -65,7 +77,12 @@ test("buildCreateWidgetInput includes weather config for weather widgets", () =>
     weatherConfig: {
       location: "Berlin",
       units: "imperial"
-    }
+    },
+    calendarConfig: {
+      provider: "ical",
+      account: "https://calendar.example.com/feed.ics",
+      timeWindow: "today",
+    },
   });
 
   assert.deepEqual(payload, {
@@ -74,5 +91,33 @@ test("buildCreateWidgetInput includes weather config for weather widgets", () =>
       location: "Berlin",
       units: "imperial"
     }
+  });
+});
+
+test("buildCreateWidgetInput includes calendar config for calendar widgets", () => {
+  const payload = buildCreateWidgetInput({
+    widgetType: "calendar",
+    weatherConfig: {
+      location: "Berlin",
+      units: "metric",
+    },
+    calendarConfig: {
+      provider: "ical",
+      account: "https://calendar.example.com/work.ics",
+      timeWindow: "next24h",
+      maxEvents: 5,
+      includeAllDay: false,
+    },
+  });
+
+  assert.deepEqual(payload, {
+    type: "calendar",
+    config: {
+      provider: "ical",
+      account: "https://calendar.example.com/work.ics",
+      timeWindow: "next24h",
+      maxEvents: 5,
+      includeAllDay: false,
+    },
   });
 });

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -24,9 +24,9 @@ export interface WeatherWidgetConfig {
 }
 
 export interface CalendarWidgetConfig {
-  sourceType?: "ical";
-  feedUrl?: string;
-  lookAheadDays?: number;
+  provider?: "ical";
+  account?: string;
+  timeWindow?: "today" | "next24h" | "next7d";
   maxEvents?: number;
   includeAllDay?: boolean;
 }


### PR DESCRIPTION
## Summary\n- add calendar admin configuration fields in client (provider, account, time window)\n- normalize and validate calendar config in API as provider/account/timeWindow\n- update calendar resolver to use time-window semantics and keep legacy config compatibility\n- add M4-3 tests for happy/error flows across API and client\n\nCloses #29\n\n## Verification\n- cd apps/api && npm test\n- cd apps/client && npm test\n- cd apps/api && npm run typecheck && npm run lint\n- cd apps/client && npm run typecheck && npm run lint\n- cd apps/api && npm run build\n- runtime smoke: API /health responds on built server\n- runtime smoke: Expo web startup log