### PR TITLE
feat(api): add /display-layout endpoint for multi-widget V2

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -4,6 +4,7 @@ import cors from "cors";
 import { usersRouter } from "./modules/users/users.routes";
 import { widgetsRouter } from "./modules/widgets/widgets.routes";
 import { widgetDataRouter } from "./modules/widgetData/widget-data.routes";
+import { displayRouter } from "./modules/display/display.routes";
 import {
   globalErrorMiddleware,
   notFoundMiddleware
@@ -24,6 +25,7 @@ export function createApp() {
   app.use("/users", usersRouter);
   app.use("/widgets", widgetsRouter);
   app.use("/widget-data", widgetDataRouter);
+  app.use("/", displayRouter);
   app.use(notFoundMiddleware);
   app.use(globalErrorMiddleware);
 

--- a/apps/api/src/modules/display/display.routes.ts
+++ b/apps/api/src/modules/display/display.routes.ts
@@ -1,0 +1,26 @@
+import { Router } from "express";
+import { usersService } from "../users/users.service";
+import { apiErrors } from "../../core/http/api-error";
+import { asyncHandler } from "../../core/http/async-handler";
+import { displayService } from "./display.service";
+
+export const displayRouter = Router();
+
+async function getPrimaryUserId(): Promise<string> {
+  const users = await usersService.getAllUsers();
+
+  if (users.length === 0) {
+    throw apiErrors.badRequest("No users exist yet. Create a user first.");
+  }
+
+  return users[0].id;
+}
+
+displayRouter.get(
+  "/display-layout",
+  asyncHandler(async (_req, res) => {
+    const userId = await getPrimaryUserId();
+    const result = await displayService.getDisplayLayout(userId);
+    res.json(result);
+  }),
+);

--- a/apps/api/src/modules/display/display.service.ts
+++ b/apps/api/src/modules/display/display.service.ts
@@ -1,0 +1,101 @@
+import type { WidgetDataState, WidgetKey } from "@ambient/shared-contracts";
+import { widgetsService } from "../widgets/widgets.service";
+import { widgetResolvers } from "../widgetData/widget-resolvers";
+
+type DisplayWidgetState = "ready" | "loading" | "error" | "empty";
+
+export interface DisplayLayoutWidgetEnvelope {
+  widgetInstanceId: string;
+  widgetKey: WidgetKey;
+  layout: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
+  state: DisplayWidgetState;
+  data: Record<string, unknown> | null;
+  meta: {
+    resolvedAt: string;
+    errorCode?: string;
+    message?: string;
+    source?: string;
+    fetchedAt?: string;
+    staleAt?: string;
+    fromCache?: boolean;
+  };
+}
+
+export interface DisplayLayoutResponse {
+  widgets: DisplayLayoutWidgetEnvelope[];
+}
+
+function normalizeState(state: WidgetDataState): DisplayWidgetState {
+  if (state === "stale") {
+    return "loading";
+  }
+
+  return state;
+}
+
+export const displayService = {
+  async getDisplayLayout(userId: string): Promise<DisplayLayoutResponse> {
+    const widgets = await widgetsService.getUserWidgets(userId);
+
+    const resolvedWidgets = await Promise.all(widgets.map(async (widget) => {
+      const resolvedAt = new Date().toISOString();
+      const resolver = widgetResolvers[widget.type as WidgetKey];
+
+      if (!resolver) {
+        return {
+          widgetInstanceId: widget.id,
+          widgetKey: widget.type as WidgetKey,
+          layout: widget.layout,
+          state: "error" as const,
+          data: null,
+          meta: {
+            resolvedAt,
+            errorCode: "UNSUPPORTED_WIDGET_TYPE",
+            message: `Unsupported widget type: ${widget.type}`,
+          },
+        };
+      }
+
+      try {
+        const resolvedWidgetData = await resolver({
+          widgetInstanceId: widget.id,
+          widgetConfig: widget.config,
+        });
+
+        return {
+          widgetInstanceId: resolvedWidgetData.widgetInstanceId,
+          widgetKey: resolvedWidgetData.widgetKey,
+          layout: widget.layout,
+          state: normalizeState(resolvedWidgetData.state),
+          data: (resolvedWidgetData.data as Record<string, unknown> | null) ?? null,
+          meta: {
+            ...resolvedWidgetData.meta,
+            resolvedAt,
+          },
+        };
+      } catch {
+        return {
+          widgetInstanceId: widget.id,
+          widgetKey: widget.type as WidgetKey,
+          layout: widget.layout,
+          state: "error" as const,
+          data: null,
+          meta: {
+            resolvedAt,
+            errorCode: "WIDGET_RESOLUTION_FAILED",
+            message: "Widget data could not be resolved.",
+          },
+        };
+      }
+    }));
+
+    return {
+      widgets: resolvedWidgets,
+    };
+  },
+};

--- a/apps/api/src/modules/widgetData/widget-data.service.ts
+++ b/apps/api/src/modules/widgetData/widget-data.service.ts
@@ -4,27 +4,12 @@ import type {
   WidgetDataEnvelope,
   WidgetKey,
 } from "@ambient/shared-contracts";
-import { resolveClockDateWidgetData } from "./resolvers/clockDate.resolver";
-import { resolveWeatherWidgetData } from "./resolvers/weather.resolver";
-import { resolveCalendarWidgetData } from "./resolvers/calendar.resolver";
+import { widgetResolvers } from "./widget-resolvers";
 
 type WidgetDataResult =
   WidgetDataEnvelope<WidgetDataByKey["clockDate"], "clockDate"> |
   WidgetDataEnvelope<WidgetDataByKey["weather"], "weather"> |
   WidgetDataEnvelope<WidgetDataByKey["calendar"], "calendar">;
-
-const widgetResolvers: {
-  [TKey in WidgetKey]: (input: {
-    widgetInstanceId: string;
-    widgetConfig: unknown;
-  }) => Promise<
-    WidgetDataEnvelope<WidgetDataByKey[TKey], TKey>
-  >;
-} = {
-  clockDate: resolveClockDateWidgetData,
-  weather: resolveWeatherWidgetData,
-  calendar: resolveCalendarWidgetData,
-};
 
 export const widgetDataService = {
   async getWidgetData(widgetId: string): Promise<WidgetDataResult | null> {

--- a/apps/api/src/modules/widgetData/widget-resolvers.ts
+++ b/apps/api/src/modules/widgetData/widget-resolvers.ts
@@ -1,0 +1,21 @@
+import type {
+  WidgetDataByKey,
+  WidgetDataEnvelope,
+  WidgetKey,
+} from "@ambient/shared-contracts";
+import { resolveCalendarWidgetData } from "./resolvers/calendar.resolver";
+import { resolveClockDateWidgetData } from "./resolvers/clockDate.resolver";
+import { resolveWeatherWidgetData } from "./resolvers/weather.resolver";
+
+export type WidgetResolver<TKey extends WidgetKey> = (input: {
+  widgetInstanceId: string;
+  widgetConfig: unknown;
+}) => Promise<WidgetDataEnvelope<WidgetDataByKey[TKey], TKey>>;
+
+export const widgetResolvers: {
+  [TKey in WidgetKey]: WidgetResolver<TKey>;
+} = {
+  clockDate: resolveClockDateWidgetData,
+  weather: resolveWeatherWidgetData,
+  calendar: resolveCalendarWidgetData,
+};

--- a/apps/api/tests/display-layout.integration.test.ts
+++ b/apps/api/tests/display-layout.integration.test.ts
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import test, { after, beforeEach } from "node:test";
+import type { Router } from "express";
+import { globalErrorMiddleware } from "../src/core/http/error-middleware";
+import { displayRouter } from "../src/modules/display/display.routes";
+import { usersRepository } from "../src/modules/users/users.repository";
+import { widgetResolvers } from "../src/modules/widgetData/widget-resolvers";
+import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
+
+interface TestUser {
+  id: string;
+  email: string;
+  createdAt: Date;
+}
+
+interface TestWidget {
+  id: string;
+  userId: string;
+  type: string;
+  config: Record<string, unknown>;
+  layout: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const originalUsersFindAll = usersRepository.findAll;
+const originalWidgetsFindAll = widgetsRepository.findAll;
+const originalClockResolver = widgetResolvers.clockDate;
+const originalWeatherResolver = widgetResolvers.weather;
+
+const mutableUsersRepository = usersRepository as unknown as {
+  findAll: () => Promise<TestUser[]>;
+};
+
+const mutableWidgetsRepository = widgetsRepository as unknown as {
+  findAll: (userId: string) => Promise<TestWidget[]>;
+};
+
+let usersStore: TestUser[] = [];
+let widgetsStore: TestWidget[] = [];
+
+beforeEach(() => {
+  usersStore = [
+    {
+      id: "user-1",
+      email: "owner@ambient.dev",
+      createdAt: new Date(),
+    },
+  ];
+  widgetsStore = [
+    {
+      id: "widget-1",
+      userId: "user-1",
+      type: "clockDate",
+      config: {},
+      layout: { x: 0, y: 0, w: 2, h: 1 },
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: "widget-2",
+      userId: "user-1",
+      type: "weather",
+      config: { location: "Amsterdam" },
+      layout: { x: 2, y: 0, w: 2, h: 1 },
+      isActive: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  mutableUsersRepository.findAll = async () => usersStore;
+  mutableWidgetsRepository.findAll = async (userId: string) => {
+    return widgetsStore.filter((widget) => widget.userId === userId);
+  };
+
+  widgetResolvers.clockDate = async ({ widgetInstanceId }) => {
+    return {
+      widgetInstanceId,
+      widgetKey: "clockDate",
+      state: "ready",
+      data: {
+        nowIso: "2026-03-21T10:00:00.000Z",
+        formattedTime: "10:00:00",
+        formattedDate: "21 March 2026",
+        weekdayLabel: "Saturday",
+      },
+      meta: {
+        source: "system",
+      },
+    };
+  };
+  widgetResolvers.weather = async ({ widgetInstanceId }) => {
+    return {
+      widgetInstanceId,
+      widgetKey: "weather",
+      state: "ready",
+      data: {
+        location: "Amsterdam",
+        temperatureC: 9.1,
+        conditionLabel: "Rain",
+      },
+      meta: {
+        source: "open-meteo",
+      },
+    };
+  };
+});
+
+after(() => {
+  mutableUsersRepository.findAll = originalUsersFindAll as typeof mutableUsersRepository.findAll;
+  mutableWidgetsRepository.findAll =
+    originalWidgetsFindAll as typeof mutableWidgetsRepository.findAll;
+  widgetResolvers.clockDate = originalClockResolver;
+  widgetResolvers.weather = originalWeatherResolver;
+});
+
+function getRouteHandler(router: Router, path: string) {
+  const routeLayer = (router as unknown as { stack?: Array<unknown> }).stack?.find((layer) => {
+    const route = (layer as { route?: { path?: string; methods?: Record<string, boolean> } })
+      .route;
+    return route?.path === path && route.methods?.get;
+  }) as
+    | {
+        route: {
+          stack: Array<{ handle: (...args: unknown[]) => Promise<void> | void }>;
+        };
+      }
+    | undefined;
+
+  if (!routeLayer) {
+    throw new Error(`Route GET ${path} not found`);
+  }
+
+  return routeLayer.route.stack[0].handle;
+}
+
+async function invokeGetRoute(router: Router, path: string) {
+  const handler = getRouteHandler(router, path);
+  const req = {
+    method: "GET",
+    path,
+    originalUrl: path,
+    params: {},
+  };
+
+  const response = {
+    statusCode: 200,
+    body: null as unknown,
+  };
+
+  const res = {
+    status(statusCode: number) {
+      response.statusCode = statusCode;
+      return res;
+    },
+    json(body: unknown) {
+      response.body = body;
+      return res;
+    },
+  };
+
+  await handler(req, res, (error: unknown) => {
+    if (error) {
+      globalErrorMiddleware(error, req as never, res as never, (() => undefined) as never);
+    }
+  });
+
+  return response;
+}
+
+test("GET /display-layout returns multiple layout-aware widget envelopes", async () => {
+  const response = await invokeGetRoute(displayRouter, "/display-layout");
+  assert.equal(response.statusCode, 200);
+
+  const body = response.body as {
+    widgets: Array<{
+      widgetInstanceId: string;
+      widgetKey: string;
+      layout: { x: number; y: number; w: number; h: number };
+      state: string;
+      data: Record<string, unknown> | null;
+      meta: { resolvedAt: string };
+    }>;
+  };
+
+  assert.equal(body.widgets.length, 2);
+  assert.equal(body.widgets[0].widgetInstanceId, "widget-1");
+  assert.deepEqual(body.widgets[0].layout, { x: 0, y: 0, w: 2, h: 1 });
+  assert.equal(body.widgets[0].state, "ready");
+  assert.equal(typeof body.widgets[0].meta.resolvedAt, "string");
+
+  assert.equal(body.widgets[1].widgetInstanceId, "widget-2");
+  assert.deepEqual(body.widgets[1].layout, { x: 2, y: 0, w: 2, h: 1 });
+  assert.equal(body.widgets[1].state, "ready");
+  assert.equal(typeof body.widgets[1].meta.resolvedAt, "string");
+});
+
+test("GET /display-layout continues when one resolver fails", async () => {
+  widgetResolvers.weather = async () => {
+    throw new Error("weather unavailable");
+  };
+
+  const response = await invokeGetRoute(displayRouter, "/display-layout");
+  assert.equal(response.statusCode, 200);
+
+  const body = response.body as {
+    widgets: Array<{
+      widgetInstanceId: string;
+      widgetKey: string;
+      state: string;
+      meta: { errorCode?: string };
+    }>;
+  };
+
+  assert.equal(body.widgets.length, 2);
+
+  const clockWidget = body.widgets.find((widget) => widget.widgetKey === "clockDate");
+  const weatherWidget = body.widgets.find((widget) => widget.widgetKey === "weather");
+
+  assert.ok(clockWidget);
+  assert.equal(clockWidget.state, "ready");
+  assert.ok(weatherWidget);
+  assert.equal(weatherWidget.state, "error");
+  assert.equal(weatherWidget.meta.errorCode, "WIDGET_RESOLUTION_FAILED");
+});

--- a/apps/api/tests/display.service.unit.test.ts
+++ b/apps/api/tests/display.service.unit.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test, { after, beforeEach } from "node:test";
+import { displayService } from "../src/modules/display/display.service";
+import { widgetResolvers } from "../src/modules/widgetData/widget-resolvers";
+import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
+
+const originalFindAll = widgetsRepository.findAll;
+const originalClockResolver = widgetResolvers.clockDate;
+const originalWeatherResolver = widgetResolvers.weather;
+
+const mutableWidgetsRepository = widgetsRepository as unknown as {
+  findAll: (userId: string) => Promise<Array<{
+    id: string;
+    userId: string;
+    type: string;
+    config: Record<string, unknown>;
+    layout: {
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+    };
+    isActive: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  }>>;
+};
+
+beforeEach(() => {
+  mutableWidgetsRepository.findAll = async () => {
+    return [
+      {
+        id: "widget-1",
+        userId: "user-1",
+        type: "clockDate",
+        config: {},
+        layout: { x: 0, y: 0, w: 2, h: 1 },
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        id: "widget-2",
+        userId: "user-1",
+        type: "weather",
+        config: { location: "Amsterdam" },
+        layout: { x: 2, y: 0, w: 2, h: 1 },
+        isActive: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+  };
+
+  widgetResolvers.clockDate = async ({ widgetInstanceId }) => {
+    return {
+      widgetInstanceId,
+      widgetKey: "clockDate",
+      state: "ready",
+      data: {
+        nowIso: "2026-03-21T10:00:00.000Z",
+        formattedTime: "10:00:00",
+        formattedDate: "21 March 2026",
+        weekdayLabel: "Saturday",
+      },
+      meta: {
+        source: "system",
+        fetchedAt: "2026-03-21T10:00:00.000Z",
+      },
+    };
+  };
+
+  widgetResolvers.weather = async ({ widgetInstanceId }) => {
+    return {
+      widgetInstanceId,
+      widgetKey: "weather",
+      state: "ready",
+      data: {
+        location: "Amsterdam",
+        temperatureC: 10.1,
+        conditionLabel: "Rain",
+      },
+      meta: {
+        source: "open-meteo",
+        fetchedAt: "2026-03-21T10:01:00.000Z",
+      },
+    };
+  };
+});
+
+after(() => {
+  mutableWidgetsRepository.findAll =
+    originalFindAll as typeof mutableWidgetsRepository.findAll;
+  widgetResolvers.clockDate = originalClockResolver;
+  widgetResolvers.weather = originalWeatherResolver;
+});
+
+test("displayService resolves all widgets and attaches layout", async () => {
+  const result = await displayService.getDisplayLayout("user-1");
+
+  assert.equal(result.widgets.length, 2);
+  assert.equal(result.widgets[0].widgetInstanceId, "widget-1");
+  assert.equal(result.widgets[0].widgetKey, "clockDate");
+  assert.deepEqual(result.widgets[0].layout, { x: 0, y: 0, w: 2, h: 1 });
+  assert.equal(result.widgets[0].state, "ready");
+  assert.equal(typeof result.widgets[0].meta.resolvedAt, "string");
+
+  assert.equal(result.widgets[1].widgetInstanceId, "widget-2");
+  assert.equal(result.widgets[1].widgetKey, "weather");
+  assert.deepEqual(result.widgets[1].layout, { x: 2, y: 0, w: 2, h: 1 });
+  assert.equal(result.widgets[1].state, "ready");
+  assert.equal(typeof result.widgets[1].meta.resolvedAt, "string");
+});
+
+test("displayService continues when one resolver throws", async () => {
+  widgetResolvers.weather = async () => {
+    throw new Error("resolver failed");
+  };
+
+  const result = await displayService.getDisplayLayout("user-1");
+  assert.equal(result.widgets.length, 2);
+
+  const clockWidget = result.widgets.find((widget) => widget.widgetKey === "clockDate");
+  const weatherWidget = result.widgets.find((widget) => widget.widgetKey === "weather");
+
+  assert.ok(clockWidget);
+  assert.equal(clockWidget.state, "ready");
+
+  assert.ok(weatherWidget);
+  assert.equal(weatherWidget.state, "error");
+  assert.equal(weatherWidget.meta.errorCode, "WIDGET_RESOLUTION_FAILED");
+});

--- a/docs/MILESTONES_v2.md
+++ b/docs/MILESTONES_v2.md
@@ -1,0 +1,125 @@
+# Ambient Screen – V2 Milestones
+
+---
+
+## M2.1 — Layout Data Model
+
+### Objective
+Introduce layout system in database and API.
+
+### Tasks
+1. Update Prisma schema
+2. Add layout fields (x, y, w, h)
+3. Remove position dependency
+4. Migrate existing data
+
+### Output
+- updated DB schema
+- migration script
+
+---
+
+## M2.2 — Layout API
+
+### Objective
+Expose layout to client.
+
+### Tasks
+1. Create GET /layout endpoint
+2. Return widgets with layout
+3. Ensure schema validation
+
+### Output
+- new endpoint
+- tested API response
+
+---
+
+## M2.3 — Display Engine Upgrade
+
+### Objective
+Render multiple widgets simultaneously.
+
+### Tasks
+1. Replace single widget logic
+2. Render list of widgets
+3. Implement layout container
+4. Ensure independent refresh loops
+
+### Output
+- multi-widget display working
+
+---
+
+## M2.4 — Grid Rendering System
+
+### Objective
+Position widgets correctly.
+
+### Tasks
+1. Implement grid container
+2. Map layout → UI positions
+3. Ensure no overlap rendering
+
+### Output
+- correct widget placement
+
+---
+
+## M2.5 — Widget Isolation
+
+### Objective
+Ensure independent widget behavior.
+
+### Tasks
+1. Isolate state per widget
+2. Isolate polling intervals
+3. Prevent shared state bugs
+
+### Output
+- stable independent widgets
+
+---
+
+## M2.6 — Admin Layout Configuration
+
+### Objective
+Allow basic layout control.
+
+### Tasks
+1. Update widget creation
+2. Allow setting x,y,w,h
+3. Validate layout input
+
+### Output
+- configurable layout system
+
+---
+
+## M2.7 — Regression Safety
+
+### Objective
+Ensure V1 stability.
+
+### Tasks
+1. Test existing widgets
+2. Verify API compatibility
+3. Validate display mode
+
+### Output
+- no regression
+
+---
+
+## M2.8 — Performance Validation
+
+### Objective
+Ensure smooth rendering.
+
+### Tasks
+1. Test multiple widgets
+2. Monitor refresh cycles
+3. Optimize re-renders
+
+### Output
+- stable performance


### PR DESCRIPTION
Summary
- add GET /display-layout route via a dedicated display module
- resolve all widgets in parallel and return layout-aware envelopes
- isolate per-widget failures so one failing resolver returns state=error without breaking others
- reuse existing widget resolvers through a shared registry to avoid duplicate logic
- keep GET /widget-data/:id behavior unchanged for V1 compatibility

Validation
- cd apps/api && npx tsc --noEmit
- cd apps/api && npm run lint
- cd apps/api && npm test

Notes
- repository already mapped layoutX/layoutY/layoutW/layoutH to layout, so no repository changes were required in this patch