### PR TITLE
feat(ui): transitions and animations (M3.4)

### DIFF
--- a/apps/client/src/features/display/animations/transitionManager.ts
+++ b/apps/client/src/features/display/animations/transitionManager.ts
@@ -1,0 +1,182 @@
+export type TransitionType = "fade" | "slide" | "none";
+
+export interface TransitionPreset {
+  durationMs: number;
+}
+
+export const transitionPresets: Record<TransitionType, TransitionPreset> = {
+  fade: { durationMs: 360 },
+  slide: { durationMs: 420 },
+  none: { durationMs: 0 },
+};
+
+export interface DashboardTransitionState<TDashboard> {
+  currentDashboard: TDashboard | null;
+  previousDashboard: TDashboard | null;
+  phase: "idle" | "animating";
+  transitionType: TransitionType;
+  transitionId: number;
+}
+
+interface CreateTransitionManagerInput<TDashboard> {
+  transitionType?: TransitionType;
+  initialDashboard?: TDashboard | null;
+}
+
+export interface TransitionManager<TDashboard> {
+  getState: () => DashboardTransitionState<TDashboard>;
+  setTransitionType: (nextType: TransitionType) => DashboardTransitionState<TDashboard>;
+  replaceDashboard: (nextDashboard: TDashboard | null) => DashboardTransitionState<TDashboard>;
+  beginDashboardTransition: (nextDashboard: TDashboard | null) => DashboardTransitionState<TDashboard>;
+  completeDashboardTransition: (transitionId: number) => DashboardTransitionState<TDashboard>;
+  cancelDashboardTransition: () => DashboardTransitionState<TDashboard>;
+}
+
+export type AnimatedItemPhase = "enter" | "stable" | "exit";
+
+export interface AnimatedItem<TItem> {
+  key: string;
+  item: TItem;
+  phase: AnimatedItemPhase;
+}
+
+export function reconcileAnimatedItems<TItem>(
+  previousItems: AnimatedItem<TItem>[],
+  nextItems: TItem[],
+  getKey: (item: TItem) => string,
+): AnimatedItem<TItem>[] {
+  const previousByKey = new Map(previousItems.map((entry) => [entry.key, entry]));
+  const nextKeys = new Set(nextItems.map(getKey));
+  const resolved: AnimatedItem<TItem>[] = [];
+
+  for (const nextItem of nextItems) {
+    const key = getKey(nextItem);
+    const previous = previousByKey.get(key);
+
+    if (!previous || previous.phase === "exit") {
+      resolved.push({
+        key,
+        item: nextItem,
+        phase: "enter",
+      });
+      continue;
+    }
+
+    resolved.push({
+      key,
+      item: nextItem,
+      phase: "stable",
+    });
+  }
+
+  for (const previous of previousItems) {
+    if (nextKeys.has(previous.key)) {
+      continue;
+    }
+
+    resolved.push({
+      key: previous.key,
+      item: previous.item,
+      phase: "exit",
+    });
+  }
+
+  return resolved;
+}
+
+export function settleAnimatedItems<TItem>(
+  animatedItems: AnimatedItem<TItem>[],
+): AnimatedItem<TItem>[] {
+  return animatedItems
+    .filter((entry) => entry.phase !== "exit")
+    .map((entry) => ({
+      ...entry,
+      phase: "stable",
+    }));
+}
+
+export function createTransitionManager<TDashboard>(
+  input: CreateTransitionManagerInput<TDashboard> = {},
+): TransitionManager<TDashboard> {
+  let state: DashboardTransitionState<TDashboard> = {
+    currentDashboard: input.initialDashboard ?? null,
+    previousDashboard: null,
+    phase: "idle",
+    transitionType: input.transitionType ?? "fade",
+    transitionId: 0,
+  };
+
+  function update(nextState: DashboardTransitionState<TDashboard>): DashboardTransitionState<TDashboard> {
+    state = nextState;
+    return state;
+  }
+
+  function getState(): DashboardTransitionState<TDashboard> {
+    return state;
+  }
+
+  function setTransitionType(nextType: TransitionType): DashboardTransitionState<TDashboard> {
+    if (state.transitionType === nextType) {
+      return state;
+    }
+
+    return update({
+      ...state,
+      transitionType: nextType,
+    });
+  }
+
+  function replaceDashboard(nextDashboard: TDashboard | null): DashboardTransitionState<TDashboard> {
+    return update({
+      ...state,
+      currentDashboard: nextDashboard,
+      previousDashboard: null,
+      phase: "idle",
+      transitionId: state.transitionId + 1,
+    });
+  }
+
+  function beginDashboardTransition(nextDashboard: TDashboard | null): DashboardTransitionState<TDashboard> {
+    if (state.transitionType === "none" || state.currentDashboard === null) {
+      return replaceDashboard(nextDashboard);
+    }
+
+    return update({
+      ...state,
+      currentDashboard: nextDashboard,
+      previousDashboard: state.currentDashboard,
+      phase: "animating",
+      transitionId: state.transitionId + 1,
+    });
+  }
+
+  function completeDashboardTransition(transitionId: number): DashboardTransitionState<TDashboard> {
+    if (state.phase !== "animating" || transitionId !== state.transitionId) {
+      return state;
+    }
+
+    return update({
+      ...state,
+      previousDashboard: null,
+      phase: "idle",
+    });
+  }
+
+  function cancelDashboardTransition(): DashboardTransitionState<TDashboard> {
+    return update({
+      ...state,
+      previousDashboard: null,
+      phase: "idle",
+      transitionId: state.transitionId + 1,
+    });
+  }
+
+  return {
+    getState,
+    setTransitionType,
+    replaceDashboard,
+    beginDashboardTransition,
+    completeDashboardTransition,
+    cancelDashboardTransition,
+  };
+}

--- a/apps/client/src/features/display/components/LayoutGrid.tsx
+++ b/apps/client/src/features/display/components/LayoutGrid.tsx
@@ -1,7 +1,13 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { StyleSheet, useWindowDimensions, View } from "react-native";
 import type { LayoutChangeEvent, ViewStyle } from "react-native";
 import type { DisplayLayoutWidgetEnvelope } from "../../../services/api/displayLayoutApi";
+import {
+  reconcileAnimatedItems,
+  settleAnimatedItems,
+  transitionPresets,
+  type AnimatedItem,
+} from "../animations/transitionManager";
 import {
   clampWidgetLayout,
   computeLayoutFrame,
@@ -21,7 +27,7 @@ interface LayoutGridProps {
 }
 
 interface PositionedWidget {
-  widget: DisplayLayoutWidgetEnvelope;
+  widgetEntry: AnimatedItem<DisplayLayoutWidgetEnvelope>;
   frameStyle: ViewStyle;
 }
 
@@ -38,17 +44,55 @@ export function LayoutGrid({
     width: windowDimensions.width,
     height: windowDimensions.height,
   });
+  const [animatedWidgetEntries, setAnimatedWidgetEntries] = useState<AnimatedItem<DisplayLayoutWidgetEnvelope>[]>(
+    () =>
+      widgets.map((widget) => ({
+        key: widget.widgetInstanceId,
+        item: widget,
+        phase: "stable",
+      })),
+  );
+  const settleTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    setAnimatedWidgetEntries((previous) => reconcileAnimatedItems(
+      previous,
+      widgets,
+      (widget) => widget.widgetInstanceId,
+    ));
+  }, [widgets]);
+
+  useEffect(() => {
+    if (!animatedWidgetEntries.some((entry) => entry.phase !== "stable")) {
+      return () => undefined;
+    }
+
+    if (settleTimeoutRef.current) {
+      clearTimeout(settleTimeoutRef.current);
+    }
+
+    settleTimeoutRef.current = setTimeout(() => {
+      setAnimatedWidgetEntries((previous) => settleAnimatedItems(previous));
+    }, transitionPresets.fade.durationMs + 40);
+
+    return () => {
+      if (settleTimeoutRef.current) {
+        clearTimeout(settleTimeoutRef.current);
+        settleTimeoutRef.current = null;
+      }
+    };
+  }, [animatedWidgetEntries]);
 
   const positionedWidgets = useMemo<PositionedWidget[]>(() => {
-    const resolvedLayouts = widgets.map((widget) =>
+    const resolvedLayouts = animatedWidgetEntries.map((entry) =>
       clampWidgetLayout({
-        layout: widget.layout,
+        layout: entry.item.layout,
         columns: DISPLAY_GRID_COLUMNS,
         rows: DISPLAY_GRID_BASE_ROWS,
       }),
     );
 
-    return widgets.map((widget, index) => {
+    return animatedWidgetEntries.map((widgetEntry, index) => {
       const frame = computeLayoutFrame({
         layout: resolvedLayouts[index],
         containerWidth: containerSize.width,
@@ -56,7 +100,7 @@ export function LayoutGrid({
       });
 
       return {
-        widget,
+        widgetEntry,
         frameStyle: {
           left: frame.left,
           top: frame.top,
@@ -65,7 +109,7 @@ export function LayoutGrid({
         },
       };
     });
-  }, [containerSize.height, containerSize.width, widgets]);
+  }, [animatedWidgetEntries, containerSize.height, containerSize.width]);
 
   function handleLayout(event: LayoutChangeEvent) {
     const { width, height } = event.nativeEvent.layout;
@@ -83,13 +127,14 @@ export function LayoutGrid({
 
   return (
     <View style={styles.container} onLayout={handleLayout}>
-      {positionedWidgets.map(({ widget, frameStyle }) => (
+      {positionedWidgets.map(({ widgetEntry, frameStyle }) => (
         <WidgetContainer
-          key={widget.widgetInstanceId}
-          widget={widget}
+          key={widgetEntry.key}
+          widget={widgetEntry.item}
           frameStyle={frameStyle}
+          animationPhase={widgetEntry.phase}
           editMode={editMode}
-          isSelected={widget.widgetInstanceId === selectedWidgetId}
+          isSelected={widgetEntry.item.widgetInstanceId === selectedWidgetId}
           containerSize={containerSize}
           onSelectWidget={onSelectWidget}
           onWidgetLayoutChange={onWidgetLayoutChange}

--- a/apps/client/src/features/display/components/WidgetContainer.tsx
+++ b/apps/client/src/features/display/components/WidgetContainer.tsx
@@ -1,7 +1,8 @@
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
-import { ActivityIndicator, PanResponder, Pressable, StyleSheet, Text, View } from "react-native";
+import { ActivityIndicator, Animated, PanResponder, Pressable, StyleSheet, Text, View } from "react-native";
 import type { StyleProp, ViewStyle } from "react-native";
 import type { DisplayLayoutWidgetEnvelope } from "../../../services/api/displayLayoutApi";
+import type { AnimatedItemPhase } from "../animations/transitionManager";
 import { renderWidgetFromKey } from "../../../widgets/widget.registry";
 import { computeWidgetScale, getWidgetErrorLabel } from "./WidgetContainer.logic";
 import {
@@ -15,6 +16,7 @@ import {
 interface WidgetContainerProps {
   widget: DisplayLayoutWidgetEnvelope;
   frameStyle: StyleProp<ViewStyle>;
+  animationPhase?: AnimatedItemPhase;
   editMode?: boolean;
   isSelected?: boolean;
   containerSize?: { width: number; height: number };
@@ -26,6 +28,7 @@ interface WidgetContainerProps {
 function WidgetContainerBase({
   widget,
   frameStyle,
+  animationPhase = "stable",
   editMode = false,
   isSelected = false,
   containerSize = { width: 0, height: 0 },
@@ -40,11 +43,45 @@ function WidgetContainerBase({
   const [dragPreview, setDragPreview] = useState({ dx: 0, dy: 0 });
   const [resizePreview, setResizePreview] = useState({ dw: 0, dh: 0 });
   const isResizingRef = useRef(false);
+  const mountOpacity = useRef(new Animated.Value(animationPhase === "enter" ? 0 : 1)).current;
+  const mountScale = useRef(new Animated.Value(animationPhase === "enter" ? 0.97 : 1)).current;
 
   const layoutRef = useRef(widget.layout);
   useEffect(() => {
     layoutRef.current = widget.layout;
   }, [widget.layout]);
+
+  useEffect(() => {
+    let toValueOpacity = 1;
+    let toValueScale = 1;
+
+    if (animationPhase === "exit") {
+      toValueOpacity = 0;
+      toValueScale = 0.98;
+    } else if (animationPhase === "enter") {
+      mountOpacity.setValue(0);
+      mountScale.setValue(0.97);
+    }
+
+    const animation = Animated.parallel([
+      Animated.timing(mountOpacity, {
+        toValue: toValueOpacity,
+        duration: 260,
+        useNativeDriver: true,
+      }),
+      Animated.timing(mountScale, {
+        toValue: toValueScale,
+        duration: 280,
+        useNativeDriver: true,
+      }),
+    ]);
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+  }, [animationPhase, mountOpacity, mountScale]);
 
   const columnWidth = containerSize.width > 0 ? containerSize.width / DISPLAY_GRID_COLUMNS : 0;
   const rowHeight = containerSize.height > 0 ? containerSize.height / DISPLAY_GRID_BASE_ROWS : 0;
@@ -137,7 +174,6 @@ function WidgetContainerBase({
     const maxHeightDelta = containerSize.height - height;
 
     return {
-      transform: [{ translateX: dragPreview.dx }, { translateY: dragPreview.dy }],
       width: clampValue(width + resizePreview.dw, 48, Math.max(48, width + maxWidthDelta)),
       height: clampValue(height + resizePreview.dh, 48, Math.max(48, height + maxHeightDelta)),
     };
@@ -178,42 +214,52 @@ function WidgetContainerBase({
   }, [scale, widget]);
 
   return (
-    <View
+    <Animated.View
       style={[
         styles.container,
         frameStyle,
         previewStyle,
         editMode ? styles.editModeContainer : null,
         editMode && isSelected ? styles.selectedContainer : null,
+        {
+          opacity: mountOpacity,
+          transform: [
+            { translateX: editMode ? dragPreview.dx : 0 },
+            { translateY: editMode ? dragPreview.dy : 0 },
+            { scale: mountScale },
+          ],
+        },
       ]}
       {...(editMode ? dragResponder.panHandlers : {})}
     >
-      <Pressable
-        disabled={!editMode}
-        style={styles.contentPressArea}
-        onPress={() => {
-          if (editMode) {
-            onSelectWidget?.(widget.widgetInstanceId);
-          }
-        }}
-      >
-        {content}
-      </Pressable>
-      {editMode ? (
+      <View style={styles.contentPressArea}>
         <Pressable
-          accessibilityRole="button"
-          style={styles.settingsButton}
-          onPress={() => onOpenWidgetSettings?.(widget.widgetInstanceId)}
+          disabled={!editMode}
+          style={styles.contentPressArea}
+          onPress={() => {
+            if (editMode) {
+              onSelectWidget?.(widget.widgetInstanceId);
+            }
+          }}
         >
-          <Text style={styles.settingsButtonLabel}>Settings</Text>
+          {content}
         </Pressable>
-      ) : null}
-      {editMode ? (
-        <View style={styles.resizeHandle} {...resizeResponder.panHandlers}>
-          <View style={styles.resizeHandleGlyph} />
-        </View>
-      ) : null}
-    </View>
+        {editMode ? (
+          <Pressable
+            accessibilityRole="button"
+            style={styles.settingsButton}
+            onPress={() => onOpenWidgetSettings?.(widget.widgetInstanceId)}
+          >
+            <Text style={styles.settingsButtonLabel}>Settings</Text>
+          </Pressable>
+        ) : null}
+        {editMode ? (
+          <View style={styles.resizeHandle} {...resizeResponder.panHandlers}>
+            <View style={styles.resizeHandleGlyph} />
+          </View>
+        ) : null}
+      </View>
+    </Animated.View>
   );
 }
 
@@ -230,6 +276,7 @@ export const WidgetContainer = memo(WidgetContainerBase, (prevProps, nextProps) 
     && prevProps.widget.layout.y === nextProps.widget.layout.y
     && prevProps.widget.layout.w === nextProps.widget.layout.w
     && prevProps.widget.layout.h === nextProps.widget.layout.h
+    && prevProps.animationPhase === nextProps.animationPhase
     && prevProps.editMode === nextProps.editMode
     && prevProps.isSelected === nextProps.isSelected
     && prevFrame.left === nextFrame.left

--- a/apps/client/src/features/display/screens/DisplayScreen.tsx
+++ b/apps/client/src/features/display/screens/DisplayScreen.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Animated,
   AppState,
+  Easing,
   Pressable,
   StyleSheet,
   Switch,
@@ -53,6 +55,11 @@ import { useRealtimeDisplaySync } from "../hooks/useRealtimeDisplaySync";
 import { API_BASE_URL } from "../../../core/config/api";
 import { createOrchestrationEngine } from "../services/orchestrationEngine";
 import {
+  createTransitionManager,
+  transitionPresets,
+  type TransitionType,
+} from "../animations/transitionManager";
+import {
   createOrchestrationRule,
   getOrchestrationRules,
   updateOrchestrationRule,
@@ -63,6 +70,8 @@ interface DisplayScreenProps {
 }
 
 const FALLBACK_REFRESH_INTERVAL_MS = 30000;
+const DISPLAY_TRANSITION_TYPE: TransitionType = "fade";
+const WIDGET_TRANSITION_LIBRARY = "react-native Animated API";
 
 export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   const [profiles, setProfiles] = useState<Profile[]>([]);
@@ -85,12 +94,25 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   const [slideshowSaveError, setSlideshowSaveError] = useState<string | null>(null);
   const [savingSlideshow, setSavingSlideshow] = useState(false);
   const [isAppActive, setIsAppActive] = useState(true);
+  const [dashboardTransitionType] = useState<TransitionType>(DISPLAY_TRANSITION_TYPE);
+  const [renderedWidgets, setRenderedWidgets] = useState<DisplayLayoutWidgetEnvelope[]>([]);
+  const [outgoingWidgets, setOutgoingWidgets] = useState<DisplayLayoutWidgetEnvelope[] | null>(null);
+  const transitionManagerRef = useRef(createTransitionManager<DisplayLayoutWidgetEnvelope[]>({
+    transitionType: DISPLAY_TRANSITION_TYPE,
+    initialDashboard: [],
+  }));
+  const transitionPendingRef = useRef(false);
+  const dashboardTransitionAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
+  const dashboardIncomingOpacity = useRef(new Animated.Value(1)).current;
+  const dashboardOutgoingOpacity = useRef(new Animated.Value(0)).current;
+  const dashboardIncomingSlide = useRef(new Animated.Value(0)).current;
 
   const setActiveProfile = useCallback(async (profileId: string) => {
     setActiveProfileId((current) => {
       if (current === profileId) {
         return current;
       }
+      transitionPendingRef.current = true;
       return profileId;
     });
     await persistActiveProfileId(profileId);
@@ -267,6 +289,29 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   }, []);
 
   useEffect(() => {
+    transitionManagerRef.current.setTransitionType(dashboardTransitionType);
+  }, [dashboardTransitionType]);
+
+  useEffect(() => {
+    if (isAppActive) {
+      return;
+    }
+
+    transitionPendingRef.current = false;
+    dashboardTransitionAnimationRef.current?.stop();
+    dashboardTransitionAnimationRef.current = null;
+    transitionManagerRef.current.cancelDashboardTransition();
+    setOutgoingWidgets(null);
+  }, [isAppActive]);
+
+  useEffect(() => {
+    console.info("[display] animation stack", {
+      dashboardTransitionType,
+      widgetAnimations: WIDGET_TRANSITION_LIBRARY,
+    });
+  }, [dashboardTransitionType]);
+
+  useEffect(() => {
     let cancelled = false;
 
     async function runInitialLoad() {
@@ -393,6 +438,87 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
       layout: draftLayoutsByWidgetId[widget.widgetInstanceId] ?? widget.layout,
     }));
   }, [draftLayoutsByWidgetId, editMode, widgets]);
+
+  useEffect(() => {
+    const transitionManager = transitionManagerRef.current;
+    const shouldAnimate = transitionPendingRef.current
+      && !editMode
+      && isAppActive
+      && dashboardTransitionType !== "none";
+
+    if (!shouldAnimate) {
+      const nextState = transitionManager.replaceDashboard(layoutWidgets);
+      setRenderedWidgets(nextState.currentDashboard ?? []);
+      setOutgoingWidgets(null);
+      transitionPendingRef.current = false;
+      dashboardTransitionAnimationRef.current?.stop();
+      dashboardTransitionAnimationRef.current = null;
+      return;
+    }
+
+    const nextState = transitionManager.beginDashboardTransition(layoutWidgets);
+    setRenderedWidgets(nextState.currentDashboard ?? []);
+
+    if (nextState.phase !== "animating" || !nextState.previousDashboard) {
+      setOutgoingWidgets(null);
+      transitionPendingRef.current = false;
+      return;
+    }
+
+    setOutgoingWidgets(nextState.previousDashboard);
+    transitionPendingRef.current = false;
+
+    dashboardTransitionAnimationRef.current?.stop();
+    const preset = transitionPresets[dashboardTransitionType];
+    dashboardIncomingOpacity.setValue(dashboardTransitionType === "fade" ? 0.35 : 0.5);
+    dashboardOutgoingOpacity.setValue(1);
+    dashboardIncomingSlide.setValue(dashboardTransitionType === "slide" ? 22 : 0);
+
+    const transitionId = nextState.transitionId;
+    dashboardTransitionAnimationRef.current = Animated.parallel([
+      Animated.timing(dashboardOutgoingOpacity, {
+        toValue: 0,
+        duration: preset.durationMs,
+        easing: Easing.inOut(Easing.quad),
+        useNativeDriver: true,
+      }),
+      Animated.timing(dashboardIncomingOpacity, {
+        toValue: 1,
+        duration: preset.durationMs,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.timing(dashboardIncomingSlide, {
+        toValue: 0,
+        duration: preset.durationMs,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]);
+
+    dashboardTransitionAnimationRef.current.start(({ finished }) => {
+      if (!finished) {
+        return;
+      }
+
+      const completedState = transitionManager.completeDashboardTransition(transitionId);
+      setRenderedWidgets(completedState.currentDashboard ?? []);
+      setOutgoingWidgets(completedState.previousDashboard);
+    });
+  }, [
+    dashboardIncomingOpacity,
+    dashboardIncomingSlide,
+    dashboardOutgoingOpacity,
+    dashboardTransitionType,
+    editMode,
+    isAppActive,
+    layoutWidgets,
+  ]);
+
+  useEffect(() => () => {
+    dashboardTransitionAnimationRef.current?.stop();
+    dashboardTransitionAnimationRef.current = null;
+  }, []);
 
   const hasLayoutChanges = useMemo(() => {
     if (!editMode) {
@@ -529,35 +655,74 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   }, [loadDisplayLayout, settingsWidget]);
 
   const frameModel = getDisplayFrameModel(undefined);
-  const hasWidgets = widgets.length > 0;
+  const hasWidgets = renderedWidgets.length > 0;
+  const hasAnyDashboardWidgets = hasWidgets || Boolean(outgoingWidgets?.length);
 
   const content = useMemo(() => {
-    if (loadingLayout && !hasWidgets) {
+    if (loadingLayout && !hasAnyDashboardWidgets) {
       const model = getDisplayStatusModel("loadingWidgets", null);
       return <DisplayStatusCard title={model.title} message={model.message} showSpinner />;
     }
 
-    if (!hasWidgets && error) {
+    if (!hasAnyDashboardWidgets && error) {
       const model = getDisplayStatusModel("error", error);
       return <DisplayStatusCard title={model.title} message={model.message} />;
     }
 
-    if (!hasWidgets) {
+    if (!hasAnyDashboardWidgets) {
       const model = getDisplayStatusModel("empty", null);
       return <DisplayStatusCard title={model.title} message={model.message} />;
     }
 
     return (
-      <LayoutGrid
-        widgets={layoutWidgets}
-        editMode={editMode}
-        selectedWidgetId={selectedWidgetId}
-        onSelectWidget={setSelectedWidgetId}
-        onWidgetLayoutChange={handleWidgetLayoutChange}
-        onOpenWidgetSettings={handleOpenWidgetSettings}
-      />
+      <View style={styles.dashboardLayerStack}>
+        <Animated.View
+          style={[
+            styles.dashboardLayer,
+            {
+              opacity: dashboardIncomingOpacity,
+              transform: [{ translateX: dashboardIncomingSlide }],
+            },
+          ]}
+        >
+          <LayoutGrid
+            widgets={renderedWidgets}
+            editMode={editMode}
+            selectedWidgetId={selectedWidgetId}
+            onSelectWidget={setSelectedWidgetId}
+            onWidgetLayoutChange={handleWidgetLayoutChange}
+            onOpenWidgetSettings={handleOpenWidgetSettings}
+          />
+        </Animated.View>
+        {outgoingWidgets ? (
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              styles.dashboardLayer,
+              {
+                opacity: dashboardOutgoingOpacity,
+              },
+            ]}
+          >
+            <LayoutGrid widgets={outgoingWidgets} />
+          </Animated.View>
+        ) : null}
+      </View>
     );
-  }, [editMode, error, handleWidgetLayoutChange, hasWidgets, layoutWidgets, loadingLayout, selectedWidgetId]);
+  }, [
+    dashboardIncomingOpacity,
+    dashboardIncomingSlide,
+    dashboardOutgoingOpacity,
+    editMode,
+    error,
+    handleWidgetLayoutChange,
+    hasAnyDashboardWidgets,
+    hasWidgets,
+    loadingLayout,
+    outgoingWidgets,
+    renderedWidgets,
+    selectedWidgetId,
+  ]);
 
   return (
     <View style={styles.screen}>
@@ -676,7 +841,7 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
       <DisplayFrame
         title={frameModel.title}
         subtitle={frameModel.subtitle}
-        footer={<Text style={styles.footerText}>{hasWidgets ? `${widgets.length} widgets live` : frameModel.footerLabel}</Text>}
+        footer={<Text style={styles.footerText}>{hasWidgets ? `${renderedWidgets.length} widgets live` : frameModel.footerLabel}</Text>}
       >
         {content}
       </DisplayFrame>
@@ -751,6 +916,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingVertical: 24,
+  },
+  dashboardLayerStack: {
+    flex: 1,
+    position: "relative",
+  },
+  dashboardLayer: {
+    ...StyleSheet.absoluteFillObject,
   },
   statusCard: {
     width: "100%",

--- a/apps/client/tests/transitionManager.test.ts
+++ b/apps/client/tests/transitionManager.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import {
+  createTransitionManager,
+  reconcileAnimatedItems,
+  settleAnimatedItems,
+  transitionPresets,
+  type AnimatedItem,
+} from "../src/features/display/animations/transitionManager";
+
+describe("transition manager", () => {
+  test("starts idle and can replace dashboard without animation", () => {
+    const manager = createTransitionManager<string[]>({
+      initialDashboard: ["dashboard-a"],
+      transitionType: "fade",
+    });
+
+    const state = manager.replaceDashboard(["dashboard-b"]);
+    expect(state.phase).toBe("idle");
+    expect(state.previousDashboard).toBeNull();
+    expect(state.currentDashboard).toEqual(["dashboard-b"]);
+  });
+
+  test("keeps previous dashboard while animating and clears it on completion", () => {
+    const manager = createTransitionManager<string[]>({
+      initialDashboard: ["dashboard-a"],
+      transitionType: "fade",
+    });
+
+    const started = manager.beginDashboardTransition(["dashboard-b"]);
+    expect(started.phase).toBe("animating");
+    expect(started.previousDashboard).toEqual(["dashboard-a"]);
+    expect(started.currentDashboard).toEqual(["dashboard-b"]);
+
+    const completed = manager.completeDashboardTransition(started.transitionId);
+    expect(completed.phase).toBe("idle");
+    expect(completed.previousDashboard).toBeNull();
+    expect(completed.currentDashboard).toEqual(["dashboard-b"]);
+  });
+
+  test("ignores stale completion ids during rapid profile switching", () => {
+    const manager = createTransitionManager<string[]>({
+      initialDashboard: ["dashboard-a"],
+      transitionType: "fade",
+    });
+
+    const first = manager.beginDashboardTransition(["dashboard-b"]);
+    const second = manager.beginDashboardTransition(["dashboard-c"]);
+    const staleCompletion = manager.completeDashboardTransition(first.transitionId);
+
+    expect(staleCompletion.phase).toBe("animating");
+    expect(staleCompletion.currentDashboard).toEqual(["dashboard-c"]);
+    expect(staleCompletion.previousDashboard).toEqual(["dashboard-b"]);
+
+    const finalState = manager.completeDashboardTransition(second.transitionId);
+    expect(finalState.phase).toBe("idle");
+    expect(finalState.previousDashboard).toBeNull();
+    expect(finalState.currentDashboard).toEqual(["dashboard-c"]);
+  });
+
+  test("none transition type bypasses animation", () => {
+    const manager = createTransitionManager<string[]>({
+      initialDashboard: ["dashboard-a"],
+      transitionType: "none",
+    });
+
+    const nextState = manager.beginDashboardTransition(["dashboard-b"]);
+    expect(nextState.phase).toBe("idle");
+    expect(nextState.previousDashboard).toBeNull();
+    expect(nextState.currentDashboard).toEqual(["dashboard-b"]);
+  });
+});
+
+describe("animated item reconciliation", () => {
+  test("marks entering and exiting widgets for mount/unmount animation", () => {
+    const previous: AnimatedItem<{ id: string }>[] = [
+      { key: "widget-a", item: { id: "widget-a" }, phase: "stable" },
+      { key: "widget-b", item: { id: "widget-b" }, phase: "stable" },
+    ];
+
+    const reconciled = reconcileAnimatedItems(
+      previous,
+      [{ id: "widget-b" }, { id: "widget-c" }],
+      (widget) => widget.id,
+    );
+
+    expect(reconciled).toEqual([
+      { key: "widget-b", item: { id: "widget-b" }, phase: "stable" },
+      { key: "widget-c", item: { id: "widget-c" }, phase: "enter" },
+      { key: "widget-a", item: { id: "widget-a" }, phase: "exit" },
+    ]);
+  });
+
+  test("settle removes exiting items and normalizes entering items", () => {
+    const settled = settleAnimatedItems([
+      { key: "widget-a", item: { id: "widget-a" }, phase: "stable" as const },
+      { key: "widget-b", item: { id: "widget-b" }, phase: "enter" as const },
+      { key: "widget-c", item: { id: "widget-c" }, phase: "exit" as const },
+    ]);
+
+    expect(settled).toEqual([
+      { key: "widget-a", item: { id: "widget-a" }, phase: "stable" },
+      { key: "widget-b", item: { id: "widget-b" }, phase: "stable" },
+    ]);
+  });
+
+  test("transition presets include fade, slide, and none variants", () => {
+    expect(transitionPresets.fade.durationMs > 0).toBeTruthy();
+    expect(transitionPresets.slide.durationMs >= transitionPresets.fade.durationMs).toBeTruthy();
+    expect(transitionPresets.none.durationMs).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated display transition manager for dashboard crossfades/slide transitions and widget enter/exit coordination
- integrate profile-switch dashboard transitions into DisplayScreen with outgoing+incoming layered rendering to prevent flicker
- add widget mount/unmount animations in LayoutGrid + WidgetContainer using React Native Animated API
- include local transition type configuration support (fade | slide | none) without DB persistence

## Transition Types
- \fade\: crossfade outgoing dashboard and incoming dashboard
- \slide\: fade + horizontal slide-in for incoming dashboard
- \none\: immediate swap (future-safe toggle)

## Performance Considerations
- uses React Native Animated API with native driver for opacity/transform animations
- keeps memoized widget containers and avoids full tree re-renders by reconciling animated widget entries
- interrupts stale transitions safely during rapid profile switching
- does not block rendering if animation is interrupted/cancelled

## Testing
- cd apps/client && npm run typecheck
- cd apps/client && npm run lint
- cd apps/client && npm test

## Milestone
- Implements M3.4: smooth dashboard and widget transitions for ambient display rotation/profile switching