### PR TITLE
feat(profiles): cloud-backed profile sync (M4.2)

### DIFF
--- a/apps/api/prisma/migrations/20260321193000_cloud_profiles_sync/migration.sql
+++ b/apps/api/prisma/migrations/20260321193000_cloud_profiles_sync/migration.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "User" ADD COLUMN "activeProfileId" TEXT;
+
+UPDATE "User" u
+SET "activeProfileId" = selected."id"
+FROM (
+  SELECT DISTINCT ON ("userId") "userId", "id"
+  FROM "Profile"
+  ORDER BY "userId", "isDefault" DESC, "createdAt" ASC
+) selected
+WHERE selected."userId" = u."id"
+  AND u."activeProfileId" IS NULL;
+
+CREATE INDEX "User_activeProfileId_idx" ON "User"("activeProfileId");
+
+ALTER TABLE "User"
+ADD CONSTRAINT "User_activeProfileId_fkey"
+FOREIGN KEY ("activeProfileId") REFERENCES "Profile"("id")
+ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -8,14 +8,18 @@ datasource db {
 }
 
 model User {
-  id        String    @id @default(uuid())
-  email     String    @unique
+  id           String    @id @default(uuid())
+  email        String    @unique
   passwordHash String
-  createdAt DateTime  @default(now())
+  createdAt    DateTime  @default(now())
+  activeProfileId String?
 
   profiles           Profile[]
   orchestrationRules OrchestrationRule[]
   sharedSessions     SharedScreenSession[]
+  activeProfile      Profile?            @relation("UserActiveProfile", fields: [activeProfileId], references: [id], onDelete: SetNull)
+
+  @@index([activeProfileId])
 }
 
 model Profile {
@@ -27,6 +31,7 @@ model Profile {
 
   user    User             @relation(fields: [userId], references: [id])
   widgets WidgetInstance[]
+  activeForUsers User[]    @relation("UserActiveProfile")
 
   @@index([userId])
 }

--- a/apps/api/src/modules/profiles/profiles.repository.ts
+++ b/apps/api/src/modules/profiles/profiles.repository.ts
@@ -22,6 +22,15 @@ export const profilesRepository = {
     });
   },
 
+  findByIdForUser(input: { id: string; userId: string }) {
+    return prisma.profile.findFirst({
+      where: {
+        id: input.id,
+        userId: input.userId,
+      },
+    });
+  },
+
   findDefaultByUser(userId: string) {
     return prisma.profile.findFirst({
       where: { userId, isDefault: true },
@@ -71,6 +80,21 @@ export const profilesRepository = {
         where: { id: profileId },
         data: { isDefault: true },
       });
+    });
+  },
+
+  getUserActiveProfileId(userId: string) {
+    return prisma.user.findUnique({
+      where: { id: userId },
+      select: { activeProfileId: true },
+    });
+  },
+
+  setUserActiveProfileId(userId: string, profileId: string | null) {
+    return prisma.user.update({
+      where: { id: userId },
+      data: { activeProfileId: profileId },
+      select: { activeProfileId: true },
     });
   },
 };

--- a/apps/api/src/modules/profiles/profiles.routes.ts
+++ b/apps/api/src/modules/profiles/profiles.routes.ts
@@ -19,9 +19,24 @@ profilesRouter.get(
   "/",
   asyncHandler(async (req, res) => {
     const userId = getRequestUserId(req);
-    await profilesService.getOrCreateDefaultProfileForUser(userId);
-    const profiles = await profilesService.getProfilesForUser(userId);
-    res.json(profiles);
+    const result = await profilesService.getProfilesWithActiveForUser(userId);
+    res.json(result);
+  }),
+);
+
+profilesRouter.get(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const idParam = req.params.id;
+    const profileId = Array.isArray(idParam) ? idParam[0] : idParam;
+    const userId = getRequestUserId(req);
+    const profile = await profilesService.getProfileByIdForUser({ userId, profileId });
+
+    if (!profile) {
+      throw apiErrors.notFound("Profile not found");
+    }
+
+    res.json(profile);
   }),
 );
 
@@ -89,5 +104,27 @@ profilesRouter.delete(
     }
 
     res.status(204).send();
+  }),
+);
+
+profilesRouter.patch(
+  "/:id/activate",
+  asyncHandler(async (req, res) => {
+    const idParam = req.params.id;
+    const profileId = Array.isArray(idParam) ? idParam[0] : idParam;
+    const userId = getRequestUserId(req);
+
+    const profile = await profilesService.activateProfileForUser({
+      userId,
+      profileId,
+    });
+
+    if (!profile) {
+      throw apiErrors.notFound("Profile not found");
+    }
+
+    res.json({
+      activeProfileId: profile.id,
+    });
   }),
 );

--- a/apps/api/src/modules/profiles/profiles.service.ts
+++ b/apps/api/src/modules/profiles/profiles.service.ts
@@ -11,9 +11,56 @@ export interface ProfileRecord {
   createdAt: Date;
 }
 
+export interface ProfilesListResult {
+  profiles: ProfileRecord[];
+  activeProfileId: string | null;
+}
+
+async function ensureActiveProfileForUser(userId: string): Promise<string | null> {
+  const userState = await profilesRepository.getUserActiveProfileId(userId);
+  if (userState?.activeProfileId) {
+    const activeProfile = await profilesRepository.findByIdForUser({
+      id: userState.activeProfileId,
+      userId,
+    });
+
+    if (activeProfile) {
+      return activeProfile.id;
+    }
+  }
+
+  const defaultProfile = await profilesRepository.findDefaultByUser(userId);
+  if (defaultProfile) {
+    await profilesRepository.setUserActiveProfileId(userId, defaultProfile.id);
+    return defaultProfile.id;
+  }
+
+  const existingProfiles = await profilesRepository.findAllByUser(userId);
+  if (existingProfiles.length > 0) {
+    const nextDefaultProfile = await profilesRepository.setDefaultProfileForUser(userId, existingProfiles[0].id);
+    await profilesRepository.setUserActiveProfileId(userId, nextDefaultProfile.id);
+    return nextDefaultProfile.id;
+  }
+
+  return null;
+}
+
 export const profilesService = {
   getProfilesForUser(userId: string) {
     return profilesRepository.findAllByUser(userId);
+  },
+
+  async getProfilesWithActiveForUser(userId: string): Promise<ProfilesListResult> {
+    await this.getOrCreateDefaultProfileForUser(userId);
+    const [profiles, activeProfileId] = await Promise.all([
+      profilesRepository.findAllByUser(userId),
+      ensureActiveProfileForUser(userId),
+    ]);
+
+    return {
+      profiles,
+      activeProfileId,
+    };
   },
 
   async getOrCreateDefaultProfileForUser(userId: string): Promise<ProfileRecord> {
@@ -34,23 +81,63 @@ export const profilesService = {
     });
   },
 
-  async resolveProfileForUser(data: { userId: string; profileId?: string | null }) {
-    if (!data.profileId) {
-      return {
-        id: data.userId,
-        userId: data.userId,
-        name: "Default",
-        isDefault: true,
-        createdAt: new Date(0),
-      };
-    }
+  async getProfileByIdForUser(data: { userId: string; profileId: string }) {
+    return profilesRepository.findByIdForUser({
+      id: data.profileId,
+      userId: data.userId,
+    });
+  },
 
-    const profile = await profilesRepository.findById(data.profileId);
-    if (!profile || profile.userId !== data.userId) {
+  async getActiveProfileIdForUser(userId: string): Promise<string | null> {
+    await this.getOrCreateDefaultProfileForUser(userId);
+    return ensureActiveProfileForUser(userId);
+  },
+
+  async activateProfileForUser(data: { userId: string; profileId: string }) {
+    const profile = await profilesRepository.findByIdForUser({
+      id: data.profileId,
+      userId: data.userId,
+    });
+
+    if (!profile) {
       return null;
     }
 
+    await profilesRepository.setUserActiveProfileId(data.userId, profile.id);
+
+    publishRealtimeEvent(
+      createRealtimeEvent({
+        type: "profile.updated",
+        profileId: profile.id,
+      }),
+    );
+    publishRealtimeEvent(
+      createRealtimeEvent({
+        type: "display.refreshRequested",
+        profileId: profile.id,
+      }),
+    );
+
     return profile;
+  },
+
+  async resolveProfileForUser(data: { userId: string; profileId?: string | null }) {
+    if (!data.profileId) {
+      const activeProfileId = await this.getActiveProfileIdForUser(data.userId);
+      if (!activeProfileId) {
+        return null;
+      }
+
+      return profilesRepository.findByIdForUser({
+        id: activeProfileId,
+        userId: data.userId,
+      });
+    }
+
+    return profilesRepository.findByIdForUser({
+      id: data.profileId,
+      userId: data.userId,
+    });
   },
 
   async createProfileForUser(data: { userId: string; name: string }) {
@@ -60,6 +147,11 @@ export const profilesService = {
       name: data.name,
       isDefault: existingProfiles.length === 0,
     });
+
+    const activeProfileId = await this.getActiveProfileIdForUser(data.userId);
+    if (!activeProfileId) {
+      await profilesRepository.setUserActiveProfileId(data.userId, createdProfile.id);
+    }
 
     publishRealtimeEvent(
       createRealtimeEvent({
@@ -78,8 +170,11 @@ export const profilesService = {
   },
 
   async renameProfileForUser(data: { userId: string; profileId: string; name: string }) {
-    const profile = await profilesRepository.findById(data.profileId);
-    if (!profile || profile.userId !== data.userId) {
+    const profile = await profilesRepository.findByIdForUser({
+      id: data.profileId,
+      userId: data.userId,
+    });
+    if (!profile) {
       return null;
     }
 
@@ -102,8 +197,11 @@ export const profilesService = {
   },
 
   async deleteProfileForUser(data: { userId: string; profileId: string }) {
-    const profile = await profilesRepository.findById(data.profileId);
-    if (!profile || profile.userId !== data.userId) {
+    const profile = await profilesRepository.findByIdForUser({
+      id: data.profileId,
+      userId: data.userId,
+    });
+    if (!profile) {
       return { deleted: false as const, reason: "notFound" as const };
     }
 
@@ -112,33 +210,31 @@ export const profilesService = {
       return { deleted: false as const, reason: "lastProfile" as const };
     }
 
+    const activeProfileIdBeforeDelete = await this.getActiveProfileIdForUser(data.userId);
+
     await profilesRepository.deleteByIdWithWidgets(profile.id);
     await orchestrationService.removeProfileFromRotationRules({
       userId: data.userId,
       profileId: profile.id,
     });
 
-    if (profile.isDefault) {
-      const remainingProfiles = await profilesRepository.findAllByUser(data.userId);
-      if (remainingProfiles.length > 0) {
-        const updatedDefaultProfile = await profilesRepository.setDefaultProfileForUser(
-          data.userId,
-          remainingProfiles[0].id,
-        );
-        publishRealtimeEvent(
-          createRealtimeEvent({
-            type: "profile.updated",
-            profileId: updatedDefaultProfile.id,
-          }),
-        );
-        publishRealtimeEvent(
-          createRealtimeEvent({
-            type: "display.refreshRequested",
-            profileId: updatedDefaultProfile.id,
-          }),
-        );
-      }
+    const remainingProfiles = await profilesRepository.findAllByUser(data.userId);
+
+    if (profile.isDefault && remainingProfiles.length > 0) {
+      await profilesRepository.setDefaultProfileForUser(data.userId, remainingProfiles[0].id);
     }
+
+    if (activeProfileIdBeforeDelete === profile.id) {
+      const nextActiveProfileId = remainingProfiles[0]?.id ?? null;
+      await profilesRepository.setUserActiveProfileId(data.userId, nextActiveProfileId);
+    }
+
+    publishRealtimeEvent(
+      createRealtimeEvent({
+        type: "display.refreshRequested",
+        profileId: remainingProfiles[0]?.id,
+      }),
+    );
 
     return { deleted: true as const };
   },

--- a/apps/api/src/modules/users/users.repository.ts
+++ b/apps/api/src/modules/users/users.repository.ts
@@ -22,20 +22,34 @@ export const usersRepository = {
 
   create(email: string, passwordHash: string) {
     const userId = randomUUID();
+    const profileId = randomUUID();
 
-    return prisma.user.create({
-      data: {
-        id: userId,
-        email,
-        passwordHash,
-        profiles: {
-          create: {
-            id: userId,
-            name: "Default",
-            isDefault: true,
-          },
+    return prisma.$transaction(async (transaction) => {
+      const user = await transaction.user.create({
+        data: {
+          id: userId,
+          email,
+          passwordHash,
         },
-      },
+      });
+
+      await transaction.profile.create({
+        data: {
+          id: profileId,
+          userId,
+          name: "Default",
+          isDefault: true,
+        },
+      });
+
+      await transaction.user.update({
+        where: { id: user.id },
+        data: {
+          activeProfileId: profileId,
+        },
+      });
+
+      return user;
     });
   },
 };

--- a/apps/api/src/modules/widgets/widgets.service.ts
+++ b/apps/api/src/modules/widgets/widgets.service.ts
@@ -24,8 +24,8 @@ export const widgetsService = {
     return widgetsRepository.findById(id);
   },
 
-  getWidgetByIdForUser(id: string, _userId: string) {
-    return widgetsRepository.findById(id);
+  getWidgetByIdForUser(id: string, userId: string) {
+    return widgetsRepository.findByIdForUser(id, userId);
   },
 
   async createWidget(data: {

--- a/apps/api/tests/display-layout.integration.test.ts
+++ b/apps/api/tests/display-layout.integration.test.ts
@@ -116,14 +116,14 @@ function getRouteHandler(router: Router, path: string) {
   return routeLayer.route.stack[0].handle;
 }
 
-async function invokeGetRoute(router: Router, path: string) {
+async function invokeGetRoute(router: Router, path: string, query?: Record<string, string>) {
   const handler = getRouteHandler(router, path);
   const req = {
     method: "GET",
     path,
     originalUrl: path,
     params: {},
-    query: {},
+    query: query ?? {},
     authUser: {
       id: "user-1",
       email: "owner@ambient.dev",
@@ -209,4 +209,14 @@ test("GET /display-layout continues when one resolver fails", async () => {
   expect(weatherWidget).toBeTruthy();
   expect(weatherWidget!.state).toBe("error");
   expect(weatherWidget!.meta.errorCode).toBe("WIDGET_RESOLUTION_FAILED");
+});
+
+test("GET /display-layout rejects unknown profile ownership context", async () => {
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async () => null as never);
+
+  const response = await invokeGetRoute(displayRouter, "/display-layout", {
+    profileId: "profile-other-user",
+  });
+
+  expect(response.statusCode).toBe(404);
 });

--- a/apps/api/tests/m0-1-vertical-slice.integration.test.ts
+++ b/apps/api/tests/m0-1-vertical-slice.integration.test.ts
@@ -6,6 +6,7 @@ import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetDataRouter } from "../src/modules/widgetData/widget-data.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -47,6 +48,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -73,6 +82,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/m1-2-create-widget-flow.integration.test.ts
+++ b/apps/api/tests/m1-2-create-widget-flow.integration.test.ts
@@ -5,6 +5,7 @@ import { usersRepository } from "../src/modules/users/users.repository";
 import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -46,6 +47,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -72,6 +81,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/m1-3-active-widget-selection.integration.test.ts
+++ b/apps/api/tests/m1-3-active-widget-selection.integration.test.ts
@@ -5,6 +5,7 @@ import { usersRepository } from "../src/modules/users/users.repository";
 import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -46,6 +47,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -72,6 +81,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/m3-1-weather-widget-backend.integration.test.ts
+++ b/apps/api/tests/m3-1-weather-widget-backend.integration.test.ts
@@ -6,6 +6,7 @@ import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetDataRouter } from "../src/modules/widgetData/widget-data.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -49,6 +50,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -70,6 +79,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/m4-1-calendar-widget-backend.integration.test.ts
+++ b/apps/api/tests/m4-1-calendar-widget-backend.integration.test.ts
@@ -6,6 +6,7 @@ import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetDataRouter } from "../src/modules/widgetData/widget-data.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -49,6 +50,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -70,6 +79,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/m6-2-qa-matrix.integration.test.ts
+++ b/apps/api/tests/m6-2-qa-matrix.integration.test.ts
@@ -6,6 +6,7 @@ import { usersRouter } from "../src/modules/users/users.routes";
 import { widgetDataRouter } from "../src/modules/widgetData/widget-data.routes";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -49,6 +50,14 @@ beforeEach(() => {
   userCounter = 0;
   widgetCounter = 0;
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
+
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(usersRepository, "findByEmail").mockImplementation(async (email: string, _passwordHash: string) => {
     return (usersStore.find((user) => user.email === email) ?? null) as never;
@@ -70,6 +79,9 @@ beforeEach(() => {
       .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) as never;
   });
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) => {
+    return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
+  });
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) => {
     return (widgetsStore.find((widget) => widget.id === id) ?? null) as never;
   });
   vi.spyOn(widgetsRepository, "create").mockImplementation(async (input) => {

--- a/apps/api/tests/profiles.routes.integration.test.ts
+++ b/apps/api/tests/profiles.routes.integration.test.ts
@@ -22,9 +22,10 @@ interface InvokeRouteOptions {
 
 let profileStore: TestProfile[] = [];
 let profileCounter = 0;
+let activeProfileId: string | null = null;
 
 beforeEach(() => {
-  profileCounter = 0;
+  profileCounter = 1;
   profileStore = [
     {
       id: "profile-default",
@@ -34,9 +35,17 @@ beforeEach(() => {
       createdAt: new Date(),
     },
   ];
+  activeProfileId = "profile-default";
 
-  vi.spyOn(profilesService, "getOrCreateDefaultProfileForUser").mockImplementation(async () => profileStore[0] as never);
-  vi.spyOn(profilesService, "getProfilesForUser").mockImplementation(async () => profileStore as never);
+  vi.spyOn(profilesService, "getProfilesWithActiveForUser").mockImplementation(async (userId: string) => ({
+    profiles: profileStore.filter((item) => item.userId === userId),
+    activeProfileId,
+  }) as never);
+
+  vi.spyOn(profilesService, "getProfileByIdForUser").mockImplementation(async ({ userId, profileId }) => {
+    return (profileStore.find((item) => item.id === profileId && item.userId === userId) ?? null) as never;
+  });
+
   vi.spyOn(profilesService, "createProfileForUser").mockImplementation(async ({ userId, name }) => {
     profileCounter += 1;
     const profile: TestProfile = {
@@ -49,6 +58,17 @@ beforeEach(() => {
     profileStore.push(profile);
     return profile as never;
   });
+
+  vi.spyOn(profilesService, "activateProfileForUser").mockImplementation(async ({ userId, profileId }) => {
+    const profile = profileStore.find((item) => item.id === profileId && item.userId === userId);
+    if (!profile) {
+      return null as never;
+    }
+
+    activeProfileId = profile.id;
+    return profile as never;
+  });
+
   vi.spyOn(profilesService, "renameProfileForUser").mockImplementation(async ({ userId, profileId, name }) => {
     const profile = profileStore.find((item) => item.id === profileId && item.userId === userId);
     if (!profile) {
@@ -58,17 +78,23 @@ beforeEach(() => {
     profile.name = name;
     return profile as never;
   });
+
   vi.spyOn(profilesService, "deleteProfileForUser").mockImplementation(async ({ userId, profileId }) => {
     const profile = profileStore.find((item) => item.id === profileId && item.userId === userId);
     if (!profile) {
       return { deleted: false, reason: "notFound" } as never;
     }
 
-    if (profileStore.length <= 1) {
+    const ownedProfiles = profileStore.filter((item) => item.userId === userId);
+    if (ownedProfiles.length <= 1) {
       return { deleted: false, reason: "lastProfile" } as never;
     }
 
     profileStore = profileStore.filter((item) => item.id !== profileId);
+    if (activeProfileId === profileId) {
+      activeProfileId = profileStore.find((item) => item.userId === userId)?.id ?? null;
+    }
+
     return { deleted: true } as never;
   });
 });
@@ -144,30 +170,80 @@ async function invokeRoute(
   return response;
 }
 
-test("profile CRUD routes create, rename, and delete profiles", async () => {
+test("GET /profiles returns authenticated user's profiles with active profile", async () => {
+  profileStore.push({
+    id: "profile-work",
+    userId: "user-1",
+    name: "Work",
+    isDefault: false,
+    createdAt: new Date(),
+  });
+  profileStore.push({
+    id: "profile-other-user",
+    userId: "user-2",
+    name: "Other User",
+    isDefault: true,
+    createdAt: new Date(),
+  });
+
+  const listResponse = await invokeRoute(profilesRouter, "get", "/");
+  expect(listResponse.statusCode).toBe(200);
+  expect(listResponse.body).toEqual({
+    profiles: [
+      expect.objectContaining({ id: "profile-default", userId: "user-1" }),
+      expect.objectContaining({ id: "profile-work", userId: "user-1" }),
+    ],
+    activeProfileId: "profile-default",
+  });
+});
+
+test("profile CRUD and activation are user-scoped", async () => {
   const createResponse = await invokeRoute(profilesRouter, "post", "/", {
     body: { name: "Work" },
   });
   expect(createResponse.statusCode).toBe(201);
 
-  const listResponse = await invokeRoute(profilesRouter, "get", "/");
-  expect(listResponse.statusCode).toBe(200);
-  const profiles = listResponse.body as TestProfile[];
-  expect(profiles.length).toBe(2);
-  expect(profiles[1].name).toBe("Work");
+  const createdProfile = createResponse.body as TestProfile;
+  expect(createdProfile.userId).toBe("user-1");
 
-  const createdProfileId = profiles[1].id;
+  const activateResponse = await invokeRoute(profilesRouter, "patch", "/:id/activate", {
+    params: { id: createdProfile.id },
+  });
+  expect(activateResponse.statusCode).toBe(200);
+  expect(activateResponse.body).toEqual({ activeProfileId: createdProfile.id });
+
+  const getByIdResponse = await invokeRoute(profilesRouter, "get", "/:id", {
+    params: { id: createdProfile.id },
+  });
+  expect(getByIdResponse.statusCode).toBe(200);
+
   const renameResponse = await invokeRoute(profilesRouter, "patch", "/:id", {
-    params: { id: createdProfileId },
+    params: { id: createdProfile.id },
     body: { name: "Office" },
   });
   expect(renameResponse.statusCode).toBe(200);
   expect((renameResponse.body as TestProfile).name).toBe("Office");
 
   const deleteResponse = await invokeRoute(profilesRouter, "delete", "/:id", {
-    params: { id: createdProfileId },
+    params: { id: createdProfile.id },
   });
   expect(deleteResponse.statusCode).toBe(204);
+});
+
+test("GET /profiles/:id rejects another user's profile", async () => {
+  profileStore.push({
+    id: "profile-other-user",
+    userId: "user-2",
+    name: "Other User",
+    isDefault: true,
+    createdAt: new Date(),
+  });
+
+  const response = await invokeRoute(profilesRouter, "get", "/:id", {
+    params: { id: "profile-other-user" },
+  });
+
+  expect(response.statusCode).toBe(404);
 });
 
 test("profile delete prevents deleting the last remaining profile", async () => {

--- a/apps/api/tests/realtime.events-emission.unit.test.ts
+++ b/apps/api/tests/realtime.events-emission.unit.test.ts
@@ -139,7 +139,7 @@ test("widgetsService emits widget.deleted and display.refreshRequested on widget
 });
 
 test("profilesService emits profile.updated and display.refreshRequested on rename", async () => {
-  vi.spyOn(profilesRepository, "findById").mockImplementation(async () => ({
+  vi.spyOn(profilesRepository, "findByIdForUser").mockImplementation(async () => ({
     id: "profile-1",
     userId: "user-1",
     name: "Before",

--- a/apps/api/tests/widget-data.service.unit.test.ts
+++ b/apps/api/tests/widget-data.service.unit.test.ts
@@ -5,7 +5,7 @@ import { resolveCalendarWidgetData } from "../src/modules/widgetData/resolvers/c
 import { resolveWeatherWidgetData } from "../src/modules/widgetData/resolvers/weather.resolver";
 
 beforeEach(() => {
-  vi.spyOn(widgetsRepository, "findById").mockImplementation(async () => {
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async () => {
     return {
       id: "widget-clock",
       profileId: "user-1",
@@ -32,6 +32,13 @@ test("widgetDataService returns normalized payload for clockDate widget", async 
   expect(result!.data).toBeTruthy();
   expect(typeof result!.data!.formattedTime).toBe("string");
   expect(typeof result!.data!.formattedDate).toBe("string");
+});
+
+test("widgetDataService returns null for another user's widget", async () => {
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockResolvedValueOnce(null as never);
+
+  const result = await widgetDataService.getWidgetDataForUser("widget-clock", "user-2");
+  expect(result).toBeNull();
 });
 
 test("weather resolver returns normalized ready payload from provider data", async () => {

--- a/apps/api/tests/widgets-config.integration.test.ts
+++ b/apps/api/tests/widgets-config.integration.test.ts
@@ -4,6 +4,7 @@ import { globalErrorMiddleware } from "../src/core/http/error-middleware";
 import { usersRepository } from "../src/modules/users/users.repository";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -63,11 +64,21 @@ beforeEach(() => {
     },
   ];
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(widgetsRepository, "findAll").mockImplementation(async (profileId: string) =>
     widgetsStore.filter((widget) => widget.profileId === profileId) as never,
   );
   vi.spyOn(widgetsRepository, "findById").mockImplementation(async (id: string) =>
+    (widgetsStore.find((widget) => widget.id === id) ?? null) as never,
+  );
+  vi.spyOn(widgetsRepository, "findByIdForUser").mockImplementation(async (id: string) =>
     (widgetsStore.find((widget) => widget.id === id) ?? null) as never,
   );
   vi.spyOn(widgetsRepository, "updateConfig").mockImplementation(async ({ id, profileId, config }) => {

--- a/apps/api/tests/widgets-layout.integration.test.ts
+++ b/apps/api/tests/widgets-layout.integration.test.ts
@@ -4,6 +4,7 @@ import { globalErrorMiddleware } from "../src/core/http/error-middleware";
 import { usersRepository } from "../src/modules/users/users.repository";
 import { widgetsRepository } from "../src/modules/widgets/widgets.repository";
 import { widgetsRouter } from "../src/modules/widgets/widgets.routes";
+import { profilesService } from "../src/modules/profiles/profiles.service";
 
 interface TestUser {
   id: string;
@@ -69,6 +70,13 @@ beforeEach(() => {
     },
   ];
 
+  vi.spyOn(profilesService, "resolveProfileForUser").mockImplementation(async ({ userId }) => ({
+    id: userId,
+    userId,
+    name: "Default",
+    isDefault: true,
+    createdAt: new Date(),
+  }) as never);
   vi.spyOn(usersRepository, "findAll").mockImplementation(async () => usersStore as never);
   vi.spyOn(widgetsRepository, "findAll").mockImplementation(async (profileId: string) =>
     widgetsStore.filter((widget) => widget.profileId === profileId) as never,

--- a/apps/client/src/features/admin/screens/AdminHomeScreen.tsx
+++ b/apps/client/src/features/admin/screens/AdminHomeScreen.tsx
@@ -14,17 +14,7 @@ import {
   setActiveWidget,
   type WidgetInstance,
 } from "../../../services/api/widgetsApi";
-import type { Profile } from "@ambient/shared-contracts";
-import { resolveActiveProfileId } from "../../profiles/profiles.logic";
-import {
-  loadPersistedActiveProfileId,
-  persistActiveProfileId,
-} from "../../profiles/profileStorage";
-import {
-  createProfile as createProfileApi,
-  deleteProfile as deleteProfileApi,
-  getProfiles as getProfilesApi,
-} from "../../../services/api/profilesApi";
+import { useCloudProfiles } from "../../profiles/useCloudProfiles";
 import {
   buildCreateWidgetInput,
   CALENDAR_PROVIDERS,
@@ -44,11 +34,20 @@ interface AdminHomeScreenProps {
 }
 
 export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScreenProps) {
-  const [profiles, setProfiles] = useState<Profile[]>([]);
-  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  const {
+    profiles,
+    activeProfileId,
+    profilesError,
+    activateProfile,
+    createProfile,
+    renameProfile,
+    deleteProfile,
+  } = useCloudProfiles();
   const [newProfileName, setNewProfileName] = useState("");
+  const [renameProfileName, setRenameProfileName] = useState("");
   const [profileError, setProfileError] = useState<string | null>(null);
   const [creatingProfile, setCreatingProfile] = useState(false);
+  const [renamingProfile, setRenamingProfile] = useState(false);
   const [deletingProfile, setDeletingProfile] = useState(false);
   const [widgets, setWidgets] = useState<WidgetInstance[]>([]);
   const [selectedWidgetType, setSelectedWidgetType] =
@@ -64,36 +63,6 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
   const [error, setError] = useState<string | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
   const [activeError, setActiveError] = useState<string | null>(null);
-
-  const loadProfiles = useCallback(async (signal?: { cancelled: boolean }) => {
-    try {
-      setProfileError(null);
-      const [responseProfiles, persistedProfileId] = await Promise.all([
-        getProfilesApi(),
-        loadPersistedActiveProfileId(),
-      ]);
-
-      if (signal?.cancelled) {
-        return;
-      }
-
-      setProfiles(responseProfiles);
-      const nextActiveProfileId = resolveActiveProfileId(responseProfiles, persistedProfileId);
-      setActiveProfileId(nextActiveProfileId);
-      if (nextActiveProfileId) {
-        await persistActiveProfileId(nextActiveProfileId);
-      }
-    } catch (err) {
-      if (signal?.cancelled) {
-        return;
-      }
-
-      console.error(err);
-      setProfiles([]);
-      setActiveProfileId(null);
-      setProfileError("Failed to load profiles");
-    }
-  }, []);
 
   const loadWidgets = useCallback(async (signal?: { cancelled: boolean }) => {
     if (!activeProfileId) {
@@ -127,22 +96,16 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
 
   useEffect(() => {
     const signal = { cancelled: false };
-
-    loadProfiles(signal);
-
-    return () => {
-      signal.cancelled = true;
-    };
-  }, [loadProfiles]);
-
-  useEffect(() => {
-    const signal = { cancelled: false };
     loadWidgets(signal);
 
     return () => {
       signal.cancelled = true;
     };
   }, [loadWidgets]);
+
+  useEffect(() => {
+    setProfileError(profilesError);
+  }, [profilesError]);
 
   async function handleCreateWidget() {
     if (!activeProfileId) {
@@ -215,17 +178,37 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
     try {
       setCreatingProfile(true);
       setProfileError(null);
-      const profile = await createProfileApi(trimmedName);
-      const nextProfiles = [...profiles, profile];
-      setProfiles(nextProfiles);
+      await createProfile(trimmedName);
       setNewProfileName("");
-      setActiveProfileId(profile.id);
-      await persistActiveProfileId(profile.id);
     } catch (err) {
       console.error(err);
-      setProfileError("Failed to create profile");
+      setProfileError(err instanceof Error ? err.message : "Failed to create profile");
     } finally {
       setCreatingProfile(false);
+    }
+  }
+
+  async function handleRenameActiveProfile() {
+    if (!activeProfileId) {
+      return;
+    }
+
+    const trimmedName = renameProfileName.trim();
+    if (!trimmedName) {
+      setProfileError("Profile name is required");
+      return;
+    }
+
+    try {
+      setRenamingProfile(true);
+      setProfileError(null);
+      await renameProfile(activeProfileId, trimmedName);
+      setRenameProfileName("");
+    } catch (err) {
+      console.error(err);
+      setProfileError(err instanceof Error ? err.message : "Failed to rename profile");
+    } finally {
+      setRenamingProfile(false);
     }
   }
 
@@ -237,17 +220,10 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
     try {
       setDeletingProfile(true);
       setProfileError(null);
-      await deleteProfileApi(activeProfileId);
-      const refreshedProfiles = await getProfilesApi();
-      const nextActiveProfileId = resolveActiveProfileId(refreshedProfiles, null);
-      setProfiles(refreshedProfiles);
-      setActiveProfileId(nextActiveProfileId);
-      if (nextActiveProfileId) {
-        await persistActiveProfileId(nextActiveProfileId);
-      }
+      await deleteProfile(activeProfileId);
     } catch (err) {
       console.error(err);
-      setProfileError("Failed to delete profile");
+      setProfileError(err instanceof Error ? err.message : "Failed to delete profile");
     } finally {
       setDeletingProfile(false);
     }
@@ -288,8 +264,7 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
                 accessibilityRole="button"
                 style={[styles.profileTab, selected && styles.profileTabSelected]}
                 onPress={async () => {
-                  setActiveProfileId(profile.id);
-                  await persistActiveProfileId(profile.id);
+                  await activateProfile(profile.id);
                 }}
               >
                 <Text style={[styles.profileTabLabel, selected && styles.profileTabLabelSelected]}>
@@ -316,6 +291,24 @@ export function AdminHomeScreen({ onEnterDisplayMode, onLogout }: AdminHomeScree
           >
             <Text style={styles.profileActionButtonLabel}>
               {creatingProfile ? "Creating..." : "New Profile"}
+            </Text>
+          </Pressable>
+          <TextInput
+            accessibilityLabel="Rename active profile"
+            style={[styles.textInput, styles.profileInput]}
+            value={renameProfileName}
+            onChangeText={setRenameProfileName}
+            placeholder="Rename active profile"
+            placeholderTextColor="#7f7f7f"
+          />
+          <Pressable
+            accessibilityRole="button"
+            style={[styles.profileActionButton, renamingProfile && styles.createButtonDisabled]}
+            onPress={handleRenameActiveProfile}
+            disabled={renamingProfile}
+          >
+            <Text style={styles.profileActionButtonLabel}>
+              {renamingProfile ? "Renaming..." : "Rename"}
             </Text>
           </Pressable>
           <Pressable

--- a/apps/client/src/features/display/screens/DisplayScreen.tsx
+++ b/apps/client/src/features/display/screens/DisplayScreen.tsx
@@ -18,9 +18,6 @@ import {
   updateWidgetsLayout,
 } from "../../../services/api/displayLayoutApi";
 import {
-  getProfiles as getProfilesApi,
-} from "../../../services/api/profilesApi";
-import {
   disableDisplayKeepAwake,
   enableDisplayKeepAwake,
 } from "../services/keepAwake";
@@ -45,12 +42,7 @@ import {
   type WidgetLayout,
 } from "../components/LayoutGrid.logic";
 import { widgetRegistry } from "../../../widgets/widget.registry";
-import type { Profile } from "@ambient/shared-contracts";
-import { resolveActiveProfileId } from "../../profiles/profiles.logic";
-import {
-  loadPersistedActiveProfileId,
-  persistActiveProfileId,
-} from "../../profiles/profileStorage";
+import { useCloudProfiles } from "../../profiles/useCloudProfiles";
 import { useRealtimeDisplaySync } from "../hooks/useRealtimeDisplaySync";
 import { useSharedScreenSession } from "../hooks/useSharedScreenSession";
 import { API_BASE_URL } from "../../../core/config/api";
@@ -75,8 +67,12 @@ const DISPLAY_TRANSITION_TYPE: TransitionType = "fade";
 const WIDGET_TRANSITION_LIBRARY = "react-native Animated API";
 
 export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
-  const [profiles, setProfiles] = useState<Profile[]>([]);
-  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  const {
+    profiles,
+    activeProfileId,
+    profilesError,
+    activateProfile,
+  } = useCloudProfiles();
   const [widgets, setWidgets] = useState<DisplayLayoutWidgetEnvelope[]>([]);
   const [draftLayoutsByWidgetId, setDraftLayoutsByWidgetId] = useState<Record<string, WidgetLayout>>({});
   const [loadingLayout, setLoadingLayout] = useState(true);
@@ -87,7 +83,6 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   const [settingsWidgetId, setSettingsWidgetId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [widgetConfigError, setWidgetConfigError] = useState<string | null>(null);
-  const [profileError, setProfileError] = useState<string | null>(null);
   const [slideshowEnabled, setSlideshowEnabled] = useState(false);
   const [slideshowIntervalSecInput, setSlideshowIntervalSecInput] = useState("60");
   const [slideshowProfileIds, setSlideshowProfileIds] = useState<string[]>([]);
@@ -131,15 +126,13 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
   const effectiveActiveProfileId = isSharedMode ? sharedSession.activeProfileId : activeProfileId;
 
   const setActiveProfile = useCallback(async (profileId: string) => {
-    setActiveProfileId((current) => {
-      if (current === profileId) {
-        return current;
-      }
-      transitionPendingRef.current = true;
-      return profileId;
-    });
-    await persistActiveProfileId(profileId);
-  }, []);
+    if (activeProfileId === profileId) {
+      return;
+    }
+
+    transitionPendingRef.current = true;
+    await activateProfile(profileId);
+  }, [activeProfileId, activateProfile]);
 
   useEffect(() => {
     enableDisplayKeepAwake();
@@ -162,36 +155,6 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
 
     return Math.min(...intervals);
   }, [widgets]);
-
-  const loadProfiles = useCallback(async (signal?: { cancelled: boolean }) => {
-    try {
-      setProfileError(null);
-      const [responseProfiles, persistedProfileId] = await Promise.all([
-        getProfilesApi(),
-        loadPersistedActiveProfileId(),
-      ]);
-
-      if (signal?.cancelled) {
-        return;
-      }
-
-      setProfiles(responseProfiles);
-      const nextActiveProfileId = resolveActiveProfileId(responseProfiles, persistedProfileId);
-      setActiveProfileId(nextActiveProfileId);
-      if (nextActiveProfileId) {
-        await persistActiveProfileId(nextActiveProfileId);
-      }
-    } catch (err) {
-      if (signal?.cancelled) {
-        return;
-      }
-
-      console.error(err);
-      setProfiles([]);
-      setActiveProfileId(null);
-      setProfileError("Failed to load profiles");
-    }
-  }, []);
 
   const loadDisplayLayout = useCallback(async (showInitialLoading: boolean) => {
     if (!effectiveActiveProfileId) {
@@ -279,15 +242,6 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
     () => getEffectivePollingIntervalMs(refreshIntervalMs, realtimeConnectionState),
     [refreshIntervalMs, realtimeConnectionState],
   );
-
-  useEffect(() => {
-    const signal = { cancelled: false };
-    void loadProfiles(signal);
-
-    return () => {
-      signal.cancelled = true;
-    };
-  }, [loadProfiles]);
 
   useEffect(() => {
     if (profiles.length === 0 || isSharedMode) {
@@ -998,8 +952,8 @@ export function DisplayScreen({ onExitDisplayMode }: DisplayScreenProps) {
       >
         {content}
       </DisplayFrame>
-      {profileError || sharedSessionError ? (
-        <Text style={styles.profileError}>{profileError ?? sharedSessionError}</Text>
+      {profilesError || sharedSessionError ? (
+        <Text style={styles.profileError}>{profilesError ?? sharedSessionError}</Text>
       ) : null}
       {settingsWidget ? (
         <WidgetSettingsModal

--- a/apps/client/src/features/profiles/useCloudProfiles.ts
+++ b/apps/client/src/features/profiles/useCloudProfiles.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "../auth/auth.context";
+import {
+  activateProfile as activateProfileApi,
+  createProfile as createProfileApi,
+  deleteProfile as deleteProfileApi,
+  getProfiles as getProfilesApi,
+  renameProfile as renameProfileApi,
+} from "../../services/api/profilesApi";
+import type { Profile } from "@ambient/shared-contracts";
+
+export function useCloudProfiles() {
+  const { token } = useAuth();
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [activeProfileId, setActiveProfileId] = useState<string | null>(null);
+  const [isLoadingProfiles, setIsLoadingProfiles] = useState(false);
+  const [profilesError, setProfilesError] = useState<string | null>(null);
+
+  const refreshProfiles = useCallback(async () => {
+    if (!token) {
+      setProfiles([]);
+      setActiveProfileId(null);
+      setProfilesError(null);
+      return;
+    }
+
+    setIsLoadingProfiles(true);
+    try {
+      const result = await getProfilesApi();
+      setProfiles(result.profiles);
+      setActiveProfileId(result.activeProfileId);
+      setProfilesError(null);
+    } catch (error) {
+      setProfiles([]);
+      setActiveProfileId(null);
+      setProfilesError(error instanceof Error ? error.message : "Failed to load profiles");
+    } finally {
+      setIsLoadingProfiles(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    void refreshProfiles();
+  }, [refreshProfiles]);
+
+  const activateProfile = useCallback(async (profileId: string) => {
+    const response = await activateProfileApi(profileId);
+    setActiveProfileId(response.activeProfileId);
+    return response.activeProfileId;
+  }, []);
+
+  const createProfile = useCallback(async (name: string) => {
+    await createProfileApi(name);
+    await refreshProfiles();
+  }, [refreshProfiles]);
+
+  const renameProfile = useCallback(async (profileId: string, name: string) => {
+    await renameProfileApi(profileId, name);
+    await refreshProfiles();
+  }, [refreshProfiles]);
+
+  const deleteProfile = useCallback(async (profileId: string) => {
+    await deleteProfileApi(profileId);
+    await refreshProfiles();
+  }, [refreshProfiles]);
+
+  return {
+    profiles,
+    activeProfileId,
+    isLoadingProfiles,
+    profilesError,
+    refreshProfiles,
+    activateProfile,
+    createProfile,
+    renameProfile,
+    deleteProfile,
+  };
+}

--- a/apps/client/src/services/api/profilesApi.ts
+++ b/apps/client/src/services/api/profilesApi.ts
@@ -1,14 +1,24 @@
 import { API_BASE_URL } from "../../core/config/api";
 import { apiFetchWithTimeout, toApiErrorMessage } from "./apiClient";
-import type { Profile } from "@ambient/shared-contracts";
+import type { Profile, ProfilesListResponse } from "@ambient/shared-contracts";
 
 const PROFILES_TIMEOUT_MS = 8000;
 
-export async function getProfiles(): Promise<Profile[]> {
+export async function getProfiles(): Promise<ProfilesListResponse> {
   const response = await apiFetchWithTimeout(`${API_BASE_URL}/profiles`, undefined, PROFILES_TIMEOUT_MS);
   if (!response.ok) {
     const message = await toApiErrorMessage(response);
     throw new Error(`Failed to fetch profiles: ${message}`);
+  }
+
+  return response.json();
+}
+
+export async function getProfile(profileId: string): Promise<Profile> {
+  const response = await apiFetchWithTimeout(`${API_BASE_URL}/profiles/${profileId}`, undefined, PROFILES_TIMEOUT_MS);
+  if (!response.ok) {
+    const message = await toApiErrorMessage(response);
+    throw new Error(`Failed to fetch profile: ${message}`);
   }
 
   return response.json();
@@ -57,4 +67,17 @@ export async function deleteProfile(profileId: string): Promise<void> {
     const message = await toApiErrorMessage(response);
     throw new Error(`Failed to delete profile: ${message}`);
   }
+}
+
+export async function activateProfile(profileId: string): Promise<{ activeProfileId: string }> {
+  const response = await apiFetchWithTimeout(`${API_BASE_URL}/profiles/${profileId}/activate`, {
+    method: "PATCH",
+  }, PROFILES_TIMEOUT_MS);
+
+  if (!response.ok) {
+    const message = await toApiErrorMessage(response);
+    throw new Error(`Failed to activate profile: ${message}`);
+  }
+
+  return response.json();
 }

--- a/apps/client/tests/profilesApi.test.ts
+++ b/apps/client/tests/profilesApi.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { setApiAuthToken } from "../src/services/api/apiClient";
+
+vi.mock("../src/core/config/api", () => ({
+  API_BASE_URL: "http://localhost:3000",
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setApiAuthToken(null);
+});
+
+test("getProfiles returns cloud profile list with activeProfileId", async () => {
+  const { getProfiles } = await import("../src/services/api/profilesApi");
+  const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({
+      profiles: [
+        {
+          id: "profile-1",
+          userId: "user-1",
+          name: "Default",
+          isDefault: true,
+          createdAt: "2026-03-21T10:00:00.000Z",
+        },
+      ],
+      activeProfileId: "profile-1",
+    }), { status: 200 }),
+  );
+
+  const result = await getProfiles();
+
+  expect(result.activeProfileId).toBe("profile-1");
+  expect(result.profiles.length).toBe(1);
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+});
+
+test("activateProfile sends authenticated PATCH request", async () => {
+  const { activateProfile } = await import("../src/services/api/profilesApi");
+  setApiAuthToken("token-123");
+
+  const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify({
+      activeProfileId: "profile-2",
+    }), { status: 200 }),
+  );
+
+  const result = await activateProfile("profile-2");
+
+  expect(result).toEqual({ activeProfileId: "profile-2" });
+  const [, requestInit] = fetchSpy.mock.calls[0] ?? [];
+  expect(requestInit).toMatchObject({
+    method: "PATCH",
+    headers: {
+      Authorization: "Bearer token-123",
+    },
+  });
+});

--- a/packages/shared-contracts/src/index.ts
+++ b/packages/shared-contracts/src/index.ts
@@ -139,6 +139,11 @@ export interface Profile {
   createdAt: string;
 }
 
+export interface ProfilesListResponse {
+  profiles: Profile[];
+  activeProfileId: string | null;
+}
+
 export type OrchestrationRuleType = "interval" | "rotation";
 
 export interface OrchestrationRule {


### PR DESCRIPTION
## Summary
Implements M4.2 cloud-backed profile sync across API, DB, and client.

## Active Profile Persistence
- Uses `User.activeProfileId` as the server source of truth.
- Adds `PATCH /profiles/:id/activate`.
- `GET /profiles` returns `{ profiles, activeProfileId }`.

## Ownership & Access Control
- Profile CRUD is authenticated and user-scoped.
- Profile-aware display/layout resolution enforces ownership.
- Widget data access enforces user ownership.

## Migration
- Adds migration `20260321193000_cloud_profiles_sync`.
- Backfills active profile per user and adds FK/index.

## Client Sync Behavior
- Adds `useCloudProfiles` state layer.
- Admin/Display use API-backed profiles + active profile.
- Profile switching persists to backend.
- No local-only profile source of truth.

## Validation
- `cd apps/api && npm run test && npm run typecheck && npm run lint`
- `cd apps/client && npm test && npm run typecheck && npm run lint`
- Prisma migration applied on local dev DB (`ambient_dev`) and status is up to date.

## Milestone
- M4.2 — Cloud Profiles & Sync
